### PR TITLE
Add enterprise readiness docs for week 1 (days 1-4)

### DIFF
--- a/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
+++ b/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
@@ -1,0 +1,120 @@
+# AgentLens Enterprise Readiness Checklist
+Start: **2026-05-02**  
+Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
+
+## Erfolgskriterien (Definition of Done)
+- Security- und Compliance-Paket verkaufsfähig (DPA/AVV, SLA, Security FAQ, Subprocessor-Liste).
+- Enterprise-Trust-Funktionen live (SSO/RBAC/Audit-Exports/Retention-Policies klar dokumentiert).
+- Operative Zuverlässigkeit nachweisbar (Monitoring, Incident-Runbook, Backup/Restore-Test).
+- Sales-Enablement fertig (1-pager, Security one-pager, Live-POC-Playbook, Referenzmaterial).
+
+## Priorität (Reihenfolge)
+1. Vertrags- und Security-Basics
+2. Zugriffs- und Governance-Funktionen
+3. Reliability + Ops-Nachweise
+4. Sales- und Procurement-Unterlagen
+
+---
+
+## Phase 1 (Tag 1–30) – Foundation
+
+### Security & Compliance
+- [ ] Finales DPA/AVV Template erstellen (inkl. TOMs, Speicherort, Löschfristen).
+- [ ] Subprocessor-Liste veröffentlichen (inkl. Zweck, Region, Link).
+- [ ] Security-Policy-Seite live: Auth, Verschlüsselung, Logging, Backups.
+- [ ] Vulnerability-Prozess definieren (Intake-Mail, Triage-SLA, Disclosure-Text).
+
+### Produkt (Must-have für Enterprise-Piloten)
+- [ ] RBAC-Minimum live: `Admin`, `Analyst`, `Read-only`.
+- [ ] API-Key-Rotation-Policy + Audit-Log-Einträge für Rotationen.
+- [ ] Tenant/Projekt-Trennung dokumentieren und im UI klar kennzeichnen.
+- [ ] PII-Handling dokumentieren (Maskierung/Retention/Export/Delete-Flows).
+
+### Reliability & Ops
+- [ ] Uptime/Health-Endpunkte + internes Alerting für Ausfälle.
+- [ ] Backup-Strategie schriftlich: Frequenz, Aufbewahrung, Restore-Schritte.
+- [ ] Einmaliger Restore-Test mit Zeitmessung und Protokoll.
+- [ ] Incident-Runbook v1 (Severity, Eskalation, Kommunikationsvorlage).
+
+### Sales Enablement
+- [ ] Security one-pager (2 Seiten) für IT/InfoSec.
+- [ ] Procurement pack v1: DPA, SLA draft, Security FAQ.
+- [ ] Enterprise-Demo-Skript (20–30 Min) mit Compliance- und Audit-Fokus.
+
+---
+
+## Phase 2 (Tag 31–60) – Hardening
+
+### Security
+- [ ] Externer Pentest (oder gleichwertiger Security-Review) beauftragen.
+- [ ] Findings abarbeiten und Report-Summary freigeben.
+- [ ] Secret-Management-Härtung (Rotation-Intervalle + Owner).
+
+### Produkt
+- [ ] SSO-Plan entscheiden: SAML oder OIDC (mind. einer produktiv).
+- [ ] Audit-Log-Export verbessern (CSV/JSON, Filter, Zeiträume).
+- [ ] Data retention controls im UI mit klarer Warnlogik.
+- [ ] Admin-Aktionen vollständig auditieren (wer/was/wann).
+
+### Reliability
+- [ ] SLO-Entwurf (z. B. 99.9%) + Error-Budget-Tracking.
+- [ ] Lasttest-Szenario definieren und 1 Benchmark-Lauf protokollieren.
+- [ ] On-call-Minimum etablieren (wer reagiert wann, Kommunikationspfad).
+
+### Sales
+- [ ] 2 POC-Designs standardisieren (EU-Compliance Fokus / Cost+Quality Fokus).
+- [ ] ROI-Rechner für Pilot → Jahresvertrag.
+- [ ] Objection-Handling-Dokument (LangSmith/Langfuse/Datadog-Vergleich).
+
+---
+
+## Phase 3 (Tag 61–90) – Enterprise Close Readiness
+
+### Compliance & Legal
+- [ ] SLA finalisieren (Supportzeiten, Reaktionszeiten, Verfügbarkeit).
+- [ ] Security Annex + Data Processing Annex final paketieren.
+- [ ] Standard-Antwortpaket für Security Questionnaires vorbereiten.
+
+### Produkt & Betrieb
+- [ ] SSO/RBAC/Audit-Endzustand live und dokumentiert.
+- [ ] Disaster-Recovery-Drill durchführen und dokumentieren.
+- [ ] Change-Management-Prozess (Release Notes + Rollback Plan) festziehen.
+
+### GTM / Closing
+- [ ] 3 belastbare Case Stories mit klaren Kennzahlen (auch anonymisiert).
+- [ ] Pilot-to-Contract Playbook final (Meilensteine, Exit-Kriterien, Entscheider-Matrix).
+- [ ] Enterprise Pricing + Vertragslaufzeit-Optionen (1/2/3 Jahre) sauber ausformuliert.
+
+---
+
+## Start ab morgen (2026-05-02) – Tagesplan für die erste Woche
+
+### Tag 1
+- [x] AVV/DPA-Outline schreiben. (2026-05-02, siehe `enterprise/AVV_DPA_OUTLINE.md`)
+- [x] Security FAQ Struktur festlegen. (2026-05-02, siehe `enterprise/SECURITY_FAQ_STRUCTURE.md`)
+- [x] Incident-Runbook Template anlegen. (2026-05-02, siehe `enterprise/INCIDENT_RUNBOOK_TEMPLATE.md`)
+
+### Tag 2
+- [x] Subprocessor-Liste und Datenflussdiagramm v1 erstellen. (2026-05-02, siehe `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md`)
+- [x] Backup/Restore-Prozess dokumentieren. (2026-05-02, siehe `enterprise/BACKUP_RESTORE_PROCESS.md`)
+
+### Tag 3
+- [x] RBAC-MVP Scope fixieren (Rollen + Rechte-Matrix). (2026-05-02, siehe `enterprise/RBAC_MVP_SCOPE.md`)
+- [x] API-Key-Rotation-Prozess inkl. Audit-Events festlegen. (2026-05-02, siehe `enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md`)
+
+### Tag 4
+- [x] Procurement-Paket v1 zusammenstellen (AVV draft, SLA draft, FAQ). (2026-05-02, siehe `enterprise/PROCUREMENT_PACK_V1.md`)
+- [x] Enterprise-Demo-Skript auf Compliance/Trust ausrichten. (2026-05-02, siehe `enterprise/ENTERPRISE_DEMO_SCRIPT_COMPLIANCE_TRUST_20_30_MIN.md`)
+
+### Tag 5
+- [ ] Restore-Test durchführen und Ergebnis protokollieren.
+- [ ] Woche-1 Review: Gaps, Blocker, nächste 2 Wochen priorisieren.
+
+---
+
+## Metriken (wöchentlich tracken)
+- [ ] # Enterprise-ready Unterlagen fertig (Soll: +2/Woche)
+- [ ] # Security/Compliance Gaps offen (Soll: fallend)
+- [ ] Median Response-Zeit auf Lead-Anfragen (Soll: < 24h)
+- [ ] # aktive Enterprise-Piloten (Soll: steigend)
+- [ ] Pilot→Vertragsquote (Soll: steigende Tendenz)

--- a/enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md
+++ b/enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md
@@ -1,0 +1,113 @@
+# API Key Rotation Process and Audit Events
+
+Stand: 2026-05-02
+Owner: Security + Platform Engineering
+Status: v1
+
+## 1. Ziel
+- Sichere, nachweisbare Rotation von API-Keys ohne unnoetigen Downtime-Risiko.
+- Vollstaendige Nachvollziehbarkeit ueber Audit-Events.
+
+## 2. Wann rotieren
+- Planmaessig: alle 90 Tage (Enterprise baseline)
+- Sofortrotation bei:
+  - Verdacht auf Key-Leak
+  - Offboarding kritischer Mitarbeitender
+  - Unautorisierte Nutzungsmuster
+
+## 3. Rotationstypen
+- `Scheduled Rotation`
+  - Regelmaessige Erneuerung.
+- `Emergency Rotation`
+  - Beschleunigter Prozess, alte Keys schnellstmoeglich deaktivieren.
+
+## 4. Standardablauf (Scheduled Rotation)
+1. Vorbereitung
+  - Betroffenen Tenant/Projekt-Key identifizieren.
+  - Verantwortliche Person (`actor`) benennen.
+2. Neuen Key erstellen
+  - Neuer Key mit gleichem Scope/Plan.
+3. Dual-Key-Phase starten (Grace Window)
+  - Alter + neuer Key parallel aktiv.
+  - Ziel: Client-Config sauber umstellen.
+4. Traffic validieren
+  - Pruefen, dass Ingest/Traces ueber neuen Key laufen.
+5. Alten Key deaktivieren
+  - Deaktivierung nach erfolgreicher Umstellung.
+6. Abschluss
+  - Ticket dokumentieren und Rotation als abgeschlossen markieren.
+
+Empfohlenes Grace Window: 24 Stunden (anpassbar pro Enterprise-Kunde).
+
+## 5. Emergency Rotation Ablauf
+1. Neuen Key sofort erstellen.
+2. Alten Key sofort deaktivieren (kein Grace Window, falls Leak verifiziert).
+3. Kundenkontakt/Owner sofort informieren.
+4. Erhoehte Beobachtung fuer 24 Stunden (invalid key errors, traffic anomalies).
+
+## 6. Audit Event Schema (MVP)
+- Event sink: `audit_log`
+- Pflichtfelder im Detail-JSON/Text:
+  - `event_type`
+  - `timestamp`
+  - `actor_id` (oder `system`)
+  - `tenant_id` / `project_id` (falls vorhanden)
+  - `api_key_prefix` (nur Prefix, nie voller Key)
+  - `reason` (`scheduled`, `emergency`, `manual`)
+  - `rotation_id` (korreliert alle Schritte)
+  - `status` (`started`, `succeeded`, `failed`)
+
+## 7. Event-Typen
+- `api_key.rotation_started`
+- `api_key.created`
+- `api_key.rotation_grace_started`
+- `api_key.rotation_validated`
+- `api_key.deactivated`
+- `api_key.rotation_completed`
+- `api_key.rotation_failed`
+
+## 8. Beispiel-Audit-Events
+
+```json
+{
+  "event_type": "api_key.rotation_started",
+  "actor_id": "admin_user_42",
+  "tenant_id": "tenant_acme",
+  "api_key_prefix": "al_abcd",
+  "reason": "scheduled",
+  "rotation_id": "rot_20260502_001",
+  "status": "started"
+}
+```
+
+```json
+{
+  "event_type": "api_key.deactivated",
+  "actor_id": "admin_user_42",
+  "tenant_id": "tenant_acme",
+  "api_key_prefix": "al_wxyz",
+  "reason": "scheduled",
+  "rotation_id": "rot_20260502_001",
+  "status": "succeeded"
+}
+```
+
+## 9. Sicherheitsregeln
+- Niemals vollen API-Key in Logs, Audit oder UI anzeigen.
+- Key-Anzeige im UI nur maskiert (z. B. `al_abcd...wxyz`).
+- Rotation darf nur durch `Admin` Rolle ausgeloest werden.
+
+## 10. Operative KPIs
+- Rotationsabdeckung: Anteil Keys mit Rotation <= 90 Tage
+- Median Rotationsdauer: `rotation_started` bis `rotation_completed`
+- Fehlerquote bei Rotation: Anteil `rotation_failed`
+- Anteil Emergency Rotations pro Monat
+
+## 11. Umsetzungshinweise im aktuellen Code
+- Bestehende Endpunkte:
+  - `POST /admin/api-keys` (create)
+  - `DELETE /admin/api-keys/{key}` (deactivate)
+- Erweiterungen fuer v1.1:
+  - `POST /admin/api-keys/{key}/rotate` (orchestrierter Ablauf)
+  - Audit-Log-Eintraege bei create/deactivate/rotate
+  - Optionale Grace-Window-Validierung (Usage-Signal)

--- a/enterprise/AVV_DPA_OUTLINE.md
+++ b/enterprise/AVV_DPA_OUTLINE.md
@@ -1,0 +1,93 @@
+# AVV/DPA Outline (Draft v0.1)
+
+Stand: 2026-05-02
+Owner: Legal + Security
+Status: Draft
+
+## 1. Parteien und Rollen
+- Verantwortlicher (Customer): Name, Anschrift, Kontakt
+- Auftragsverarbeiter (AgentLens): Name, Anschrift, Kontakt
+- Datenschutzkontakt/DPO: Mailbox und Eskalationskontakt
+
+## 2. Gegenstand und Dauer der Verarbeitung
+- Gegenstand: Bereitstellung von AgentLens Observability Platform
+- Art der Verarbeitung: Erhebung, Speicherung, Auswertung, Export, Loeschung
+- Laufzeit: Vertragslaufzeit + definierte Nachlauf-/Loeschfristen
+
+## 3. Art der Daten und Kategorien betroffener Personen
+- Datenkategorien:
+  - Prompt-/Response-Inhalte
+  - Metadaten (Model, Tokens, Cost, Timestamp)
+  - Account-/Nutzerdaten (Name, E-Mail, Rolle)
+  - Betriebsdaten (Logs, Audit Events)
+- Betroffenengruppen:
+  - Mitarbeitende des Kunden
+  - Endnutzer des Kunden (falls durch Inhalte betroffen)
+
+## 4. Zweckbindung und dokumentierte Weisungen
+- Verarbeitung ausschliesslich zur Vertragserfuellung
+- Weisungen nur in Textform (Ticket, E-Mail, Vertragsanhang)
+- Umgang mit unklaren/risikoreichen Weisungen
+
+## 5. Technische und Organisatorische Massnahmen (TOMs)
+- Zugriffsschutz:
+  - Rollenbasiertes Berechtigungskonzept (Admin, Analyst, Read-only)
+  - Starke Authentifizierung fuer Admin-Zugaenge
+- Vertraulichkeit:
+  - TLS fuer Daten in Transit
+  - Verschluesselung ruhender Daten (DB/Backups)
+- Integritaet:
+  - Audit-Logs fuer Admin- und Compliance-Aktionen
+  - Change- und Release-Prozess mit Rollback
+- Verfuegbarkeit:
+  - Monitoring/Alerting
+  - Backup-/Restore-Prozess mit Regeltest
+- Belastbarkeit:
+  - Incident-Runbook und Eskalationspfad
+- Trennung:
+  - Tenant-/Projekttrennung auf Daten- und API-Ebene
+
+## 6. Unterauftragsverarbeiter (Subprocessor)
+- Referenz auf aktuelle Subprocessor-Liste (URL)
+- Verfahren fuer neue Subprocessor inkl. Vorankuendigung
+- Einspruchsprozess des Kunden
+
+## 7. Drittlandtransfers
+- Angaben zu Datenregionen
+- Transfermechanismen (falls anwendbar): SCCs, Angemessenheitsbeschluss
+- Zusicherungen zu Zugriff und Schutzmassnahmen
+
+## 8. Betroffenenrechte und Supportpflichten
+- Unterstuetzung bei Auskunft, Loeschung, Berichtigung, Portabilitaet
+- Fristen und SLA fuer Rueckmeldungen
+
+## 9. Meldung von Datenschutzvorfaellen
+- Meldeweg und Kontaktpunkt
+- Erstinformation innerhalb definierter Frist
+- Mindestinhalt einer Vorfallmeldung
+
+## 10. Speicherort, Aufbewahrung, Loeschfristen
+- Primaere Speicherregion(en)
+- Backup-Aufbewahrung
+- Loeschfristen nach Vertragsende
+- Nachweisfaehige Loeschung (Protokoll/Audit Event)
+
+## 11. Kontrollrechte und Nachweise
+- Bereitstellung von Security-Dokumentation (FAQ, Policies, Pen-Test Summary)
+- Audit-Rechte nach Vorankuendigung
+- Vertraulichkeitsgrenzen fuer Audit-Unterlagen
+
+## 12. Rueckgabe und Loeschung bei Vertragsende
+- Exportmoeglichkeiten (CSV/JSON)
+- Zeitfenster fuer Export vor Loeschung
+- Endgueltige Loeschbestaetigung
+
+## 13. Haftung, Vertraulichkeit, Schlussbestimmungen
+- Verweis auf Hauptvertrag/SLA
+- Vertraulichkeitsklauseln
+- Rangfolge bei Widerspruechen zwischen Anlagen
+
+## Offene Punkte fuer Finalisierung
+- Juristische Endredaktion nach Zielmarkt (DE/EU/US)
+- Exakte Fristen fuer Retention und Incident-Kommunikation
+- Finale Subprocessor-URL und Change-Notification-Prozess

--- a/enterprise/BACKUP_RESTORE_PROCESS.md
+++ b/enterprise/BACKUP_RESTORE_PROCESS.md
@@ -1,0 +1,112 @@
+# Backup and Restore Process
+
+Stand: 2026-05-02
+Owner: Engineering
+Status: v1
+
+## 1. Purpose
+- Define a repeatable backup and restore process for AgentLens runtime data.
+- Cover frequency, retention, restore steps, and verification.
+
+## 2. Scope
+- In scope:
+  - SQLite operational database (all core tables, including requests, evaluations, traces, demo requests, audit log)
+- Out of scope:
+  - Application source code (already covered by Git)
+  - Secret values (managed by deployment platform secrets)
+
+## 3. Source of Truth
+- Database location is derived from `DATABASE_URL`.
+- Current default in code is `sqlite+aiosqlite:///./observability.db`.
+- Production example in comments: `sqlite+aiosqlite:////data/llm_observe.db`.
+
+## 4. Backup Policy v1
+- Frequency:
+  - Daily full backup (once every 24h)
+  - Additional on-demand backup before schema changes or major releases
+- Retention:
+  - Daily backups: 30 days
+  - Weekly snapshot: 12 weeks
+  - Monthly snapshot: 12 months
+- Storage:
+  - Keep backups outside the active runtime path
+  - Encrypt at rest in backup storage
+
+## 5. Backup Procedure (SQLite)
+
+### 5.1 Preferred method (SQLite online backup)
+Use `sqlite3` when available:
+
+```powershell
+sqlite3 observability.db ".timeout 5000" ".backup backup/observability_$(Get-Date -Format yyyyMMdd_HHmmss).db"
+```
+
+### 5.2 Fallback method (file copy during maintenance window)
+If `sqlite3` is not available, stop writes briefly and copy file:
+
+```powershell
+Copy-Item -LiteralPath .\observability.db -Destination .\backup\observability_$(Get-Date -Format yyyyMMdd_HHmmss).db
+```
+
+### 5.3 Integrity check after backup
+```powershell
+sqlite3 .\backup\<backup_file>.db "PRAGMA integrity_check;"
+```
+Expected result: `ok`
+
+## 6. Restore Procedure
+
+### 6.1 Pre-restore checklist
+- Identify target backup file.
+- Confirm incident/ticket approval for restore.
+- Stop application writes (or put app in maintenance mode).
+- Preserve current DB as pre-restore snapshot.
+
+### 6.2 Restore steps
+1. Create safety snapshot of current file:
+```powershell
+Copy-Item -LiteralPath .\observability.db -Destination .\backup\pre_restore_$(Get-Date -Format yyyyMMdd_HHmmss).db
+```
+2. Replace database with selected backup:
+```powershell
+Copy-Item -LiteralPath .\backup\<selected_backup>.db -Destination .\observability.db -Force
+```
+3. Start application and run smoke tests:
+  - `GET /requests/stats`
+  - `GET /compliance/stats`
+  - `GET /traces`
+
+### 6.3 Post-restore validation
+- Confirm expected record counts and newest timestamps.
+- Confirm dashboard pages load.
+- Confirm ingest endpoint accepts new events.
+
+## 7. Recovery Targets (initial v1)
+- RPO target: <= 24 hours (daily backup cadence)
+- RTO target: <= 60 minutes for standard restore
+
+## 8. Logging and Evidence
+- For every backup and restore, record:
+  - Timestamp (UTC)
+  - Operator
+  - Source DB path
+  - Backup filename
+  - Integrity check result
+  - Restore duration (if restore executed)
+
+## 9. Restore Drill Cadence
+- Run restore drill at least once per month.
+- Execute in non-production first.
+- Capture measured restore time and issues.
+
+## 10. Railway Notes (production)
+- Ensure persistent volume is used for SQLite path from `DATABASE_URL`.
+- Backup automation can run as scheduled task that:
+  - Executes SQLite backup
+  - Uploads encrypted backup to external storage
+  - Retains according to policy in section 4
+
+## 11. Action Items to Operationalize v1
+- Add scheduled backup job in deployment environment.
+- Add backup status check in weekly ops review.
+- Add monthly restore drill entry to incident/reliability calendar.

--- a/enterprise/ENTERPRISE_DEMO_SCRIPT_COMPLIANCE_TRUST_20_30_MIN.md
+++ b/enterprise/ENTERPRISE_DEMO_SCRIPT_COMPLIANCE_TRUST_20_30_MIN.md
@@ -1,0 +1,87 @@
+# Enterprise Demo Script (20-30 min)
+
+Stand: 2026-05-02
+Owner: Sales Engineering
+Status: v1
+
+## 1. Demo objective
+- Show that AgentLens is not only useful for LLM quality and cost, but also procurement-ready on compliance, auditability, and operations basics.
+
+## 2. Audience
+- CTO / VP Engineering
+- Security / InfoSec reviewer
+- Procurement stakeholder
+
+## 3. Timing plan (25 min default)
+- 0:00-2:00: Context and success criteria
+- 2:00-8:00: Product value (quality, cost, traces)
+- 8:00-15:00: Compliance and audit controls
+- 15:00-21:00: Governance (RBAC, key rotation, retention)
+- 21:00-25:00: Procurement pack walk-through + next steps
+
+## 4. Pre-demo checklist
+- Demo API key active (`al_demo_agentlens` or tenant key).
+- Dashboard reachable.
+- Example traces available.
+- Compliance endpoints reachable.
+- Procurement docs open locally in `enterprise/`.
+
+## 5. Talk track and click path
+
+## 5.1 Opening (2 min)
+- "Today we will validate three enterprise questions:  
+  1) Can we trust the data controls?  
+  2) Can we audit critical actions?  
+  3) Is there a concrete procurement package?"
+
+## 5.2 Core observability value (6 min)
+- Show dashboard KPIs (`/requests/stats` view in UI).
+- Show worst responses and root-cause patterns.
+- Show trace waterfall (`/traces`) to highlight per-step visibility.
+- Message: "Operational transparency is immediate, not post-hoc."
+
+## 5.3 Compliance and audit controls (7 min)
+- Open compliance page (`/compliance.html`).
+- Demonstrate:
+  - export capability (`/compliance/export`)
+  - retention policy view (`/compliance/retention`)
+  - audit log (`/compliance/audit-log`)
+- Message: "Data lifecycle actions are controllable and inspectable."
+
+## 5.4 Governance trust block (6 min)
+- Present RBAC scope doc:
+  - `enterprise/RBAC_MVP_SCOPE.md`
+- Present API key rotation process + audit events:
+  - `enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md`
+- Highlight:
+  - Admin-only key operations
+  - planned 90-day rotation baseline
+  - audit event schema for each rotation phase
+
+## 5.5 Procurement readiness close (4 min)
+- Open package index:
+  - `enterprise/PROCUREMENT_PACK_V1.md`
+- Walk through:
+  - AVV/DPA outline
+  - SLA draft
+  - Security FAQ
+  - Subprocessor/data flow document
+- Message: "We can start legal/security review immediately, not after pilot."
+
+## 6. Objection handling snippets
+- "Do you support GDPR workflows?"
+  - "Yes, export/retention/delete endpoints and audit logging are already in place."
+- "How do you manage incident communication?"
+  - "Runbook defines severity, escalation, and customer update templates."
+- "What if an API key is leaked?"
+  - "Rotation process supports emergency replacement and documented audit trail."
+
+## 7. Success criteria for the call
+- Security reviewer accepts FAQ + subprocessor draft as review baseline.
+- Procurement accepts AVV/SLA drafts for redlining.
+- Technical champion agrees on pilot scope and timeline.
+
+## 8. Follow-up package (send within 24h)
+- `enterprise/PROCUREMENT_PACK_V1.md`
+- `enterprise/ENTERPRISE_DEMO_SCRIPT_COMPLIANCE_TRUST_20_30_MIN.md`
+- Any customer-specific notes from Q&A

--- a/enterprise/INCIDENT_RUNBOOK_TEMPLATE.md
+++ b/enterprise/INCIDENT_RUNBOOK_TEMPLATE.md
@@ -1,0 +1,102 @@
+# Incident Runbook Template (v1)
+
+Stand: 2026-05-02
+Owner: Engineering + Security
+Status: Template
+
+## 1. Zweck und Scope
+- Dieses Runbook beschreibt Detection, Bewertung, Eskalation und Kommunikation fuer Security- und Availability-Incidents.
+- Scope: Produktionssysteme, Kundendaten, Auth/Zugriff, API- und Dashboard-Verfuegbarkeit.
+
+## 2. Rollen im Incident
+- Incident Commander (IC): fuehrt Lage und Entscheidungen
+- Tech Lead: technische Analyse und Mitigation
+- Communications Lead: interne/externe Kommunikation
+- Scribe: Timeline und Entscheidungen dokumentieren
+
+## 3. Severity Matrix
+- Sev 1 (kritisch):
+  - Breiter Ausfall oder potenzieller Datenabfluss
+  - Initiale Kundenkommunikation: <= 60 Minuten
+- Sev 2 (hoch):
+  - Starke Einschraenkung zentraler Funktionen
+  - Initiale Kundenkommunikation: <= 4 Stunden
+- Sev 3 (mittel):
+  - Teilfunktion betroffen, Workaround verfuegbar
+  - Kommunikation: im regulaeren Updatezyklus
+- Sev 4 (niedrig):
+  - Geringe Auswirkung, kein unmittelbares Kundenrisiko
+
+## 4. Trigger und Eingangskanaele
+- Monitoring-Alert
+- Interne Meldung (Team)
+- Kundenmeldung (Support)
+- Security Intake Mail (z. B. security@...)
+
+## 5. Triage-Checkliste (erste 15 Minuten)
+- Incident-ID erstellen:
+- Zeitpunkt der Entdeckung:
+- Betroffene Systeme/Endpoints:
+- Potenziell betroffene Kunden/Tenants:
+- Datentypen betroffen (ja/nein):
+- Vorlaeufige Severity:
+- IC benannt (Name):
+
+## 6. Eskalationspfad
+- Sev 1: IC + CTO/Head of Eng + Security + Support sofort
+- Sev 2: IC + Eng Lead + Support innerhalb 30 Minuten
+- Sev 3/4: Ticket + zustaendiges Team im naechsten Bereitschaftsfenster
+
+## 7. Technische Reaktion
+- Eindammen:
+  - Zugriffe begrenzen, Tokens/API-Keys rotieren, Features ggf. deaktivieren
+- Ursacheanalyse:
+  - Logs, Audit Events, Deploy-Historie, Infrastruktur-Aenderungen
+- Wiederherstellung:
+  - Fix ausrollen, Services validieren, Monitoring pruefen
+
+## 8. Kommunikationsvorlagen
+### 8.1 Interne Erstmeldung
+Betreff: [INCIDENT][SEV-X] <Kurzbeschreibung>  
+Inhalt:
+- Was passiert ist
+- Betroffene Systeme
+- Vorlaeufige Auswirkung
+- Naechstes Update um <Uhrzeit>
+
+### 8.2 Kunden-Erstmeldung
+Betreff: Incident Notice [SEV-X] - <Service/Feature>  
+Inhalt:
+- Wir untersuchen aktuell eine Stoerung von <Service>.
+- Startzeit (UTC): <Zeit>
+- Aktueller Impact: <Beschreibung>
+- Naechstes Update: <Zeit>
+
+### 8.3 Abschlussmeldung
+Betreff: Resolved Incident [SEV-X] - <Service/Feature>  
+Inhalt:
+- Incident beendet um <Zeit>
+- Root Cause (kurz)
+- Korrekturmassnahmen
+- Praeventive Follow-ups
+
+## 9. Abschlusskriterien
+- Service stabil und Monitoring gruen
+- Kommunikationsabschluss gesendet
+- Timeline und Entscheidungen dokumentiert
+- Follow-up Tickets erstellt und priorisiert
+
+## 10. Postmortem Template (innerhalb 5 Arbeitstage)
+- Incident-ID:
+- Zeitraum:
+- Impact (Kunden, Daten, Verfuegbarkeit):
+- Root Cause:
+- Was gut lief:
+- Was verbessert werden muss:
+- Konkrete Massnahmen mit Owner + Due Date:
+
+## 11. KPI fuer Incident-Prozess
+- MTTD (Mean Time to Detect)
+- MTTR (Mean Time to Resolve)
+- Zeit bis Erstkommunikation
+- Anteil wiederkehrender Ursachen

--- a/enterprise/PROCUREMENT_PACK_V1.md
+++ b/enterprise/PROCUREMENT_PACK_V1.md
@@ -1,0 +1,53 @@
+# Procurement Pack v1
+
+Stand: 2026-05-02
+Owner: Sales + Security + Legal
+Status: Internal draft package for enterprise procurement
+
+## 1. Purpose
+- Provide a first complete procurement package for enterprise pilots.
+- Bundle legal, security, and operational trust artifacts in one place.
+
+## 2. Package Contents (v1)
+- AVV/DPA draft outline:
+  - `enterprise/AVV_DPA_OUTLINE.md`
+- SLA draft:
+  - `enterprise/SLA_DRAFT_V1.md`
+- Security FAQ:
+  - `enterprise/SECURITY_FAQ_V1.md`
+- Subprocessor list + data flow:
+  - `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md`
+- Incident runbook template:
+  - `enterprise/INCIDENT_RUNBOOK_TEMPLATE.md`
+- Backup/restore process:
+  - `enterprise/BACKUP_RESTORE_PROCESS.md`
+- RBAC scope:
+  - `enterprise/RBAC_MVP_SCOPE.md`
+- API key rotation + audit schema:
+  - `enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md`
+
+## 3. What this package answers for procurement
+- Data processing roles and scope.
+- Baseline service commitments and response times.
+- Security controls and operational practices.
+- Data export, retention, and deletion controls.
+- Subprocessor visibility and data flow transparency.
+
+## 4. Known gaps (to close before enterprise close readiness)
+- Final legal redline for DPA/AVV and SLA terms.
+- Published subprocessor page with final region/entity fields.
+- Vulnerability disclosure process and mailbox finalization.
+- SSO production status and documentation.
+
+## 5. Recommended external sharing order
+1. Security FAQ v1
+2. AVV/DPA outline
+3. SLA draft
+4. Subprocessor list + data flow
+5. Backup/incident appendices on request
+
+## 6. Internal sign-off checklist
+- Security sign-off: pending
+- Legal sign-off: pending
+- Sales enablement sign-off: pending
+- Version tag assigned: pending

--- a/enterprise/RBAC_MVP_SCOPE.md
+++ b/enterprise/RBAC_MVP_SCOPE.md
@@ -1,0 +1,69 @@
+# RBAC MVP Scope (Admin / Analyst / Read-only)
+
+Stand: 2026-05-02
+Owner: Product + Engineering + Security
+Status: Scope fixed (MVP)
+
+## 1. Ziel
+- Minimal belastbares RBAC fuer Enterprise-Piloten definieren.
+- Rollen: `Admin`, `Analyst`, `Read-only`.
+- Fokus auf API/Compliance/Audit/Billing-nahe Aktionen.
+
+## 2. Rollenbeschreibung
+- `Admin`
+  - Vollzugriff auf Tenant/Projekt-Einstellungen, API-Keys, Retention, Loeschaktionen und Exporte.
+  - Darf sicherheits- und kostenrelevante Konfiguration aendern.
+- `Analyst`
+  - Operativer Zugriff auf Dashboards, Debug, Traces, Exporte.
+  - Kein Zugriff auf sicherheitskritische Admin-Aktionen (Key-Management, Delete, Retention-Policy).
+- `Read-only`
+  - Lesender Zugriff auf Dashboards und Observability-Ansichten.
+  - Keine Konfigurations- oder Export-/Delete-Aktionen.
+
+## 3. Rechte-Matrix (MVP)
+
+| Bereich | Endpoint/Action | Admin | Analyst | Read-only |
+|---|---|---:|---:|---:|
+| Ingest | `POST /ingest` (mit API-Key des Workloads) | Allow | Allow | Allow |
+| Dashboard KPIs | `GET /requests/*` | Allow | Allow | Allow |
+| Prompt Debug | `GET /debug/requests*` | Allow | Allow | Allow |
+| Traces lesen | `GET /traces`, `GET /traces/{id}` | Allow | Allow | Allow |
+| Traces schreiben | `POST /traces*` | Allow | Allow | Deny |
+| Budget Alert lesen | `GET /alerts/budget` | Allow | Allow | Allow |
+| Budget Alert aendern | `POST/DELETE /alerts/budget` | Allow | Deny | Deny |
+| Compliance Export | `GET /compliance/export` | Allow | Allow | Deny |
+| Retention ansehen | `GET /compliance/retention` | Allow | Allow | Allow |
+| Retention aendern | `POST /compliance/retention`, `POST /compliance/retention/run` | Allow | Deny | Deny |
+| Loeschung | `DELETE /compliance/requests*` | Allow | Deny | Deny |
+| Audit Log lesen | `GET /compliance/audit-log` | Allow | Allow | Deny |
+| API-Key Management | `POST/GET/DELETE /admin/api-keys*` | Allow | Deny | Deny |
+| Demo Admin/Exports | `GET /demo-request*` (admin-token geschuetzt) | Allow | Deny | Deny |
+| Billing Checkout | `GET /billing/checkout/{plan}` | Allow | Allow | Allow |
+
+## 4. Tenant/Projekt-Prinzipien
+- Rollen sind tenant-scoped, nicht global.
+- Jeder API-Key ist genau einem Tenant/Projekt zugeordnet.
+- Cross-tenant Zugriff ist immer `Deny`.
+
+## 5. Audit-Pflichtige Aktionen (MVP)
+- API-Key erstellt/deaktiviert/rotiert
+- Retention-Policy geaendert oder manuell ausgefuehrt
+- Datenexport ausgefuehrt
+- Loeschaktionen ausgefuehrt (einzeln/bulk)
+- Budget Alerts geaendert
+
+## 6. Implementierungsumfang fuer MVP
+- Auth-Layer erweitert um:
+  - User/Service Principal mit Rolle
+  - Tenant-ID Kontext
+- Enforcement:
+  - RBAC-Checks zentral vor Route-Handlern
+- Migration:
+  - Mapping existierender Admin-Token-Flows auf Rolle `Admin`
+- UI:
+  - Sichtbarkeit von Admin-Aktionen role-aware ausblenden
+
+## 7. Akzeptanzkriterien
+- Jede geschuetzte Aktion liefert bei fehlender Berechtigung `403`.
+- Kein Role Escalation Pfad ueber Query-Parameter/Header.
+- Jede admin-kritische Aktion erzeugt Audit-Log-Eintrag.

--- a/enterprise/SECURITY_FAQ_STRUCTURE.md
+++ b/enterprise/SECURITY_FAQ_STRUCTURE.md
@@ -1,0 +1,86 @@
+# Security FAQ Struktur (v0.1)
+
+Stand: 2026-05-02
+Owner: Security + Solutions Engineering
+Zielgruppe: IT, InfoSec, Procurement
+Status: Struktur freigegeben, Antworten ausstehend
+
+## 0. Dokumentsteuerung
+- Version, Datum, Owner
+- Gueltigkeitsbereich (Produkt, Cloud/Self-host)
+- Kontakt fuer Security-Fragen
+
+## 1. Unternehmen und Governance
+- Wer ist AgentLens? (Entity, Sitz, Kontakt)
+- Gibt es ein Security-Programm und Verantwortlichkeiten?
+- Wie werden Security-Risiken bewertet und priorisiert?
+
+## 2. Produktarchitektur und Datenfluss
+- Welche Komponenten verarbeiten Kundendaten?
+- Wie erfolgt Tenant-/Projekttrennung?
+- Welche Daten verlassen die Kundenumgebung (wenn ueberhaupt)?
+
+## 3. Datenklassifikation und PII
+- Welche Datentypen werden verarbeitet?
+- Wie wird PII erkannt oder minimiert?
+- Welche Konfigurationen gibt es fuer Maskierung/Redaktion?
+
+## 4. Zugriffskontrolle und Authentifizierung
+- Welche Rollen gibt es (Admin, Analyst, Read-only)?
+- Wie werden Nutzer angelegt/deaktiviert?
+- Ist MFA/SSO verfuegbar oder geplant?
+
+## 5. Verschluesselung und Schluesselmanagement
+- Verschluesselung in Transit (TLS-Versionen, Zertifikate)
+- Verschluesselung at Rest (Datenbank, Backups)
+- Wer verwaltet Schluessel und Rotation?
+
+## 6. Logging, Audit und Monitoring
+- Welche sicherheitsrelevanten Events werden geloggt?
+- Wie lange werden Audit-Logs aufbewahrt?
+- Gibt es Alerts fuer Anomalien/Ausfaelle?
+
+## 7. Vulnerability Management
+- Wie koennen Schwachstellen gemeldet werden?
+- Welche Triage- und Fix-SLAs gelten?
+- Gibt es regelmaessige Scans/Reviews?
+
+## 8. Incident Response
+- Wie wird ein Security Incident klassifiziert?
+- Wie schnell werden Kunden informiert?
+- Welche Informationen werden in Incident-Updates geliefert?
+
+## 9. Business Continuity, Backup und Recovery
+- Wie sehen Backup-Frequenz und Aufbewahrung aus?
+- Wann wurde der letzte Restore-Test durchgefuehrt?
+- Gibt es ein dokumentiertes Disaster-Recovery-Verfahren?
+
+## 10. Subprocessor und Drittlandtransfer
+- Welche Subprocessor werden eingesetzt und warum?
+- In welchen Regionen werden Daten verarbeitet?
+- Welche Transfermechanismen werden genutzt?
+
+## 11. Compliance und Vertragsunterlagen
+- Ist ein DPA/AVV verfuegbar?
+- Welche Annexe/Policies werden bereitgestellt?
+- Welche Supportzeiten und SLA-Optionen gibt es?
+
+## 12. Kundenkontrollen und Datenrechte
+- Wie funktionieren Export, Loeschung und Retention?
+- Wie werden DSAR-Anfragen unterstuetzt?
+- Welche Admin-Kontrollen hat der Kunde selbst?
+
+## 13. Secure Development Lifecycle (optional, empfohlen)
+- Code Reviews, Teststrategie, Release-Freigaben
+- Secret Management und Zugriff auf Produktionssysteme
+- Abhaengigkeitsmanagement und Patch-Prozess
+
+## Antwortformat pro Frage
+- Kurzantwort (2-4 Saetze)
+- Technischer Nachweis/Beleg (Policy, Screenshot, API-Endpoint)
+- Verweis auf weiterfuehrendes Dokument
+
+## Minimalpaket fuer v1
+- 20-30 Top-Fragen aus Sections 2, 4, 5, 6, 7, 8, 10, 11
+- Einheitliches Antwortniveau (nicht marketinglastig)
+- Abnahme durch Security + Legal + Sales

--- a/enterprise/SECURITY_FAQ_V1.md
+++ b/enterprise/SECURITY_FAQ_V1.md
@@ -1,0 +1,50 @@
+# Security FAQ v1
+
+Stand: 2026-05-02
+Owner: Security + Solutions Engineering
+Status: Draft answers for procurement/security review
+
+## 1) Welche Authentifizierung nutzt AgentLens?
+AgentLens nutzt API-Keys fuer Ingest- und Trace-nahe API-Zugriffe. Der Key kann als `X-API-Key` Header oder als Query-Parameter uebergeben werden. Ungueltige oder inaktive Keys werden mit `403` abgewiesen.
+
+## 2) Gibt es rollenbasierte Berechtigungen?
+Das RBAC-MVP mit `Admin`, `Analyst` und `Read-only` ist als Scope definiert und in Umsetzung. Die Rechte-Matrix liegt in `enterprise/RBAC_MVP_SCOPE.md` und priorisiert Schutz fuer Key-Management, Retention und Delete-Aktionen.
+
+## 3) Wie wird Datenverkehr geschuetzt?
+Die Anwendung setzt Security-Header (u. a. `Strict-Transport-Security`, CSP, `X-Frame-Options`, `X-Content-Type-Options`). In Produktion wird TLS fuer Verbindungen zur Plattform vorausgesetzt.
+
+## 4) Wie wird Datenzugriff getrennt?
+Datenabfragen in den Dashboard- und Trace-Endpoints sind API-Key-gebunden und filtern auf den jeweiligen Key-Kontext. Das reduziert das Risiko unautorisierter Einsicht zwischen Projekten/Tenants.
+
+## 5) Welche Daten verarbeitet AgentLens?
+Verarbeitet werden Prompt-/Response-Inhalte, Modell- und Token-Metadaten, Kostenmetriken, Trace-Spans und Betriebsdaten wie Audit- und Retention-Informationen. Details sind im AVV/DPA-Outline dokumentiert.
+
+## 6) Wie funktionieren Export und Loeschung?
+Compliance-Endpunkte unter `/compliance` ermoeglichen Export (JSON/CSV), Einzel- und Bulk-Loeschung sowie Retention-Policy-Steuerung. Relevante Aktionen werden im Audit-Log protokolliert.
+
+## 7) Gibt es Audit-Logs?
+Ja. Compliance-relevante Aktionen wie Exporte, Loeschungen und Policy-Aenderungen werden in `audit_log` abgelegt. Fuer API-Key-Rotationen ist ein erweitertes Event-Schema in `enterprise/API_KEY_ROTATION_PROCESS_AND_AUDIT_EVENTS.md` definiert.
+
+## 8) Wie wird Retention umgesetzt?
+Retention kann konfiguriert und manuell ausgelost werden (`/compliance/retention`, `/compliance/retention/run`). Die Policy enthaelt Aufbewahrungsdauer, Aktivierungsstatus und Zeitstempel letzter Ausfuehrung.
+
+## 9) Gibt es Schutz gegen Missbrauch der API?
+Ja. Es gibt Request-Limits ueber `slowapi` auf zentralen Endpunkten und ein Body-Size-Limit (256 KB) fuer HTTP Requests. Das reduziert Abuse- und DoS-Risiken im MVP.
+
+## 10) Wie ist Incident Response geregelt?
+Es existiert ein Incident-Runbook mit Severity-Matrix, Eskalationspfad und Kommunikationsvorlagen. Das Template ist unter `enterprise/INCIDENT_RUNBOOK_TEMPLATE.md` abgelegt.
+
+## 11) Wie ist Backup/Restore organisiert?
+Ein schriftlicher Prozess fuer Backup, Restore, Integritaetspruefung und RPO/RTO-Ziele ist vorhanden. Referenz: `enterprise/BACKUP_RESTORE_PROCESS.md`.
+
+## 12) Welche Subprocessor werden eingesetzt?
+Die aktuelle v1-Liste inklusive Zweck und Datenfluss ist in `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md` dokumentiert. Einige Integrationen sind optional und nur aktiv, wenn entsprechende Umgebungsvariablen gesetzt sind.
+
+## 13) Wird SSO unterstuetzt?
+SSO ist in der Enterprise-Roadmap enthalten, aber nicht als abgeschlossen markiert. Der aktuelle Fokus liegt auf RBAC-MVP und Audit-/Governance-Grundlagen.
+
+## 14) Gibt es ein Vulnerability-Meldeverfahren?
+Das Verfahren ist in der Enterprise-Checkliste als offener Foundation-Punkt vorgesehen. Bis zur Finalisierung sollte eine dedizierte Security-Intake-Adresse und Triage-SLA vertraglich benannt werden.
+
+## 15) Welche rechtlichen Unterlagen sind verfuegbar?
+Fuer Procurement v1 liegen ein AVV/DPA-Outline, ein SLA-Draft und diese Security-FAQ vor. Finalisierung erfolgt nach Legal-Review und kundenspezifischer Vertragsabstimmung.

--- a/enterprise/SLA_DRAFT_V1.md
+++ b/enterprise/SLA_DRAFT_V1.md
@@ -1,0 +1,67 @@
+# SLA Draft v1
+
+Stand: 2026-05-02
+Owner: Legal + Engineering
+Status: Draft (for procurement review)
+
+## 1. Scope
+- This SLA applies to the managed AgentLens hosted service.
+- Self-hosted deployments are excluded unless separately contracted.
+
+## 2. Service Commitment (Draft)
+- Monthly availability target: 99.9% for production API and core dashboard endpoints.
+- Measurement window: calendar month (UTC).
+- Planned maintenance excluded if announced at least 48 hours in advance.
+
+## 3. Severity and Initial Response Times
+- Sev 1 (critical outage or data exposure risk): initial response <= 1 hour.
+- Sev 2 (major degradation): initial response <= 4 hours.
+- Sev 3 (minor degradation): initial response <= 1 business day.
+- Sev 4 (questions/low impact): initial response <= 2 business days.
+
+## 4. Support Coverage (Draft)
+- Standard: Monday-Friday, 09:00-18:00 CET/CEST.
+- Sev 1 emergency escalation: 24/7 best effort (for enterprise plans with on-call addendum).
+
+## 5. Incident Communication
+- Sev 1: first customer notice within 60 minutes after confirmation.
+- Sev 2: first customer notice within 4 hours after confirmation.
+- Update cadence during active incident:
+  - Sev 1: every 60 minutes
+  - Sev 2: every 4 hours
+
+## 6. Backup and Recovery Targets
+- RPO target: <= 24 hours.
+- RTO target: <= 60 minutes.
+- Backup/restore process reference:
+  - `enterprise/BACKUP_RESTORE_PROCESS.md`
+
+## 7. Security and Compliance References
+- AVV/DPA outline:
+  - `enterprise/AVV_DPA_OUTLINE.md`
+- Subprocessor and data flow list:
+  - `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md`
+- Security FAQ:
+  - `enterprise/SECURITY_FAQ_V1.md`
+
+## 8. Service Credits (Draft placeholders)
+- Availability 99.0% to 99.89%: 10% monthly service credit.
+- Availability 95.0% to 98.99%: 25% monthly service credit.
+- Availability <95.0%: 50% monthly service credit.
+- Credits are capped at the monthly recurring fee for the affected service month.
+
+## 9. Customer Responsibilities
+- Customer secures own application-layer secrets and end-user access controls.
+- Customer reports incidents promptly via agreed support channel.
+- Customer follows API usage limits and fair-use requirements.
+
+## 10. Exclusions
+- Force majeure events.
+- Customer-side network or infrastructure issues.
+- Misconfiguration by customer in self-managed integrations.
+- Third-party provider outages outside direct control.
+
+## 11. Open Items for final contract
+- Final support timezone and business-hour definition.
+- Exact credit claim process and deadline.
+- Enterprise plan differentiation (Starter/Team/Scale/Custom).

--- a/enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md
+++ b/enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md
@@ -1,0 +1,57 @@
+# Subprocessor List and Data Flow v1
+
+Stand: 2026-05-02
+Owner: Security + Legal
+Status: Draft v1 (to validate before external publication)
+
+## 1. Scope
+- This document covers subprocessors used by the hosted AgentLens service.
+- Self-hosted customer deployments may use a different vendor set.
+- Regions and transfer mechanisms must be confirmed in production account settings before external sharing.
+
+## 2. Subprocessor List (v1)
+
+| Subprocessor | Purpose | Data Categories | Region | Transfer/Legal Basis | Status |
+|---|---|---|---|---|---|
+| Railway | Application hosting, runtime, and persistent volume for SQLite database | LLM call payloads, metadata, audit data, account-related records, logs | Configured in Railway project (to confirm exact region) | DPA + SCCs as needed | Active |
+| Anthropic (optional) | LLM judge for quality scoring in evaluation pipeline (`ANTHROPIC_API_KEY`) | Truncated prompt/input/output segments used for scoring | Anthropic service region per account configuration | DPA/SCCs as needed | Optional |
+| Stripe (optional) | Checkout and subscription billing (`/billing/checkout/{plan}`) | Billing metadata, plan selection, payment session data | Stripe region per account configuration | Stripe DPA | Optional |
+| Resend (optional) | Email notifications for demo requests (`RESEND_API_KEY`) | Lead contact data (name, email, company, message) | Resend region per account configuration | Resend DPA | Optional |
+| Customer-configured webhook endpoint (optional) | Outbound notifications for demo requests and budget alerts | Event payloads including operational and lead metadata | Defined by customer endpoint | Customer-controlled destination | Optional |
+
+## 3. Non-subprocessor Notes
+- OpenAI and Anthropic APIs used by SDK users in their own apps are customer-side integrations and not automatically subprocessors of hosted AgentLens.
+- GitHub/PyPI are distribution/dev channels and are not in the primary production data path for customer runtime data.
+
+## 4. Data Flow Diagram v1
+
+```mermaid
+flowchart TD
+    A["Customer App / SDK"] -->|"POST /ingest"| B["AgentLens API (FastAPI)"]
+    B --> C["SQLite DB (requests, traces, demo_requests, audit_log)"]
+    B --> D["In-process Queue Worker"]
+    D --> E["Evaluation Engine"]
+    E -->|"if ANTHROPIC_API_KEY"| F["Anthropic API (optional judge)"]
+    E --> G["Evaluations stored in SQLite"]
+    C --> H["Dashboard & Debug Pages"]
+    C --> I["Compliance Export / Retention / Delete APIs"]
+    B --> J["Demo Request API"]
+    J --> C
+    J -->|"optional webhook"| K["Customer Webhook Endpoint"]
+    J -->|"optional email"| L["Resend API"]
+    B --> M["Billing API"]
+    M -->|"checkout session"| N["Stripe API"]
+    D -->|"optional budget webhook"| K
+```
+
+## 5. Change Management for Subprocessors
+- Additions or major changes require:
+  - Security review
+  - Legal review
+  - Update of this list and customer-facing security documentation
+- Target notice period for customer-facing updates: 30 days when contractually required.
+
+## 6. Open Validation Items (before external publication)
+- Confirm exact production hosting region in Railway.
+- Confirm legal entity names and DPA links for each listed subprocessor.
+- Confirm whether optional features are enabled in current production environment.


### PR DESCRIPTION
## Summary
Adds Enterprise Readiness Week-1 documentation (Days 1-4) for AgentLens.

## Included
- Updated checklist: `ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md`
- Added `enterprise/` docs:
  - AVV/DPA outline
  - Security FAQ structure + v1 FAQ
  - Incident runbook template
  - Subprocessor list + data flow v1
  - Backup/restore process
  - RBAC MVP scope
  - API key rotation process + audit events
  - SLA draft v1
  - Procurement pack v1
  - Enterprise demo script (20-30 min)

## Notes
- `SITE_AUDIT_2026-05-01.md` intentionally not included.
- This PR focuses on documentation and readiness artifacts.
