### PR TITLE
Fix uptime workflow conditional for webhook secret

### DIFF
--- a/.github/workflows/uptime-health-alert.yml
+++ b/.github/workflows/uptime-health-alert.yml
@@ -28,7 +28,9 @@ jobs:
           echo "Health check ok."
 
       - name: Alert webhook on failure
-        if: failure() && secrets.INTERNAL_ALERT_WEBHOOK_URL != ''
+        if: failure() && env.INTERNAL_ALERT_WEBHOOK_URL != ''
+        env:
+          INTERNAL_ALERT_WEBHOOK_URL: ${{ secrets.INTERNAL_ALERT_WEBHOOK_URL }}
         shell: bash
         run: |
           payload=$(cat <<EOF
@@ -45,4 +47,4 @@ jobs:
           curl -sS -X POST \
             -H "Content-Type: application/json" \
             -d "$payload" \
-            "${{ secrets.INTERNAL_ALERT_WEBHOOK_URL }}"
+            "$INTERNAL_ALERT_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
Fixes GitHub Actions workflow validation error in uptime health alert.

## What changed
- Replaced invalid `if: failure() && secrets.INTERNAL_ALERT_WEBHOOK_URL != ''`
- Uses `env.INTERNAL_ALERT_WEBHOOK_URL` mapped from secret in the alert step
- Keeps webhook alert optional and only on failed health checks

## Result
Workflow can be parsed and executed again.
