### PR TITLE
Launch enterprise trust center pages and sitemap links

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -170,6 +170,11 @@ async def subprocessors_page():
     return FileResponse("dashboard/subprocessors.html")
 
 
+@app.get("/enterprise", include_in_schema=False)
+async def enterprise_page():
+    return FileResponse("dashboard/enterprise.html")
+
+
 @app.get("/sitemap.xml", include_in_schema=False)
 async def sitemap():
     return FileResponse("dashboard/sitemap.xml", media_type="application/xml")

--- a/dashboard/enterprise.html
+++ b/dashboard/enterprise.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Enterprise Trust Center - AgentLens</title>
+  <meta name="description" content="AgentLens Enterprise Trust Center: security posture, compliance controls, subprocessors, operational reliability, and procurement package." />
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      --bg:#0a0f1d; --surface:#11182f; --surface2:#131e38; --border:#263556;
+      --text:#e7ecff; --muted:#9aa8c6; --accent:#7c9bff; --good:#4ade80;
+    }
+    body { margin:0; font-family: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif; background:radial-gradient(1200px 500px at 20% -5%, #1a2650 0%, #0a0f1d 50%); color:var(--text); }
+    a { color:#a8beff; text-decoration:none; }
+    a:hover { text-decoration:underline; }
+    .wrap { max-width:1080px; margin:0 auto; padding:2rem 1.2rem 3rem; }
+    .top { display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; flex-wrap:wrap; }
+    .brand { font-weight:800; font-size:1.05rem; color:#fff; }
+    .brand span { color:var(--accent); }
+    .nav { display:flex; gap:0.8rem; flex-wrap:wrap; }
+    .nav a { border:1px solid var(--border); background:rgba(15,22,43,.7); padding:.45rem .75rem; border-radius:8px; font-size:.82rem; }
+    .hero { border:1px solid var(--border); background:linear-gradient(180deg, rgba(19,30,56,.95), rgba(12,18,36,.95)); border-radius:14px; padding:1.5rem; margin-top:1rem; }
+    .badge { display:inline-block; border:1px solid #3a4f7b; color:#b9c8ef; border-radius:999px; padding:.2rem .65rem; font-size:.72rem; }
+    h1 { margin:.8rem 0 .55rem; font-size:clamp(1.6rem,3.5vw,2.35rem); line-height:1.15; }
+    .lead { color:var(--muted); max-width:760px; margin:0 0 1.2rem; }
+    .cta { display:flex; gap:.75rem; flex-wrap:wrap; }
+    .btn { display:inline-block; border-radius:9px; padding:.55rem .95rem; font-weight:700; font-size:.84rem; border:1px solid var(--border); }
+    .btn.primary { background:var(--accent); color:#091127; border-color:transparent; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:1rem; margin-top:1.2rem; }
+    .card { border:1px solid var(--border); background:var(--surface); border-radius:12px; padding:1rem; }
+    .card h3 { margin:.05rem 0 .35rem; font-size:.95rem; }
+    .card p, .card li { color:var(--muted); font-size:.83rem; line-height:1.6; }
+    .stack { display:grid; grid-template-columns:1fr; gap:1rem; margin-top:1rem; }
+    .stack h2 { margin:.1rem 0 .45rem; font-size:1.08rem; }
+    .mini { font-size:.76rem; color:#bac7e6; margin-top:.45rem; }
+    ul { margin:.45rem 0 0 1rem; padding:0; }
+    .kpi { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:.7rem; margin-top:1rem; }
+    .kpi .box { border:1px solid var(--border); background:var(--surface2); border-radius:10px; padding:.75rem; }
+    .kpi .v { font-size:1.25rem; font-weight:800; color:#dbe4ff; }
+    .kpi .l { color:var(--muted); font-size:.75rem; }
+    .status { color:var(--good); font-weight:700; }
+    footer { margin-top:2rem; color:var(--muted); font-size:.78rem; text-align:center; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">Agent<span>Lens</span> Enterprise</div>
+      <div class="nav">
+        <a href="/">Home</a>
+        <a href="/security">Security</a>
+        <a href="/subprocessors">Subprocessors</a>
+        <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <span class="badge">Enterprise Trust Center</span>
+      <h1>Security, Compliance, and Operational Trust for production AI</h1>
+      <p class="lead">This page is designed for CTOs, InfoSec, Legal, and Procurement stakeholders evaluating AgentLens for enterprise rollout. It consolidates controls, governance evidence, and procurement-ready materials in one place.</p>
+      <div class="cta">
+        <a class="btn primary" href="/book-demo?plan=enterprise&source=trust-center">Book Enterprise Demo</a>
+        <a class="btn" href="mailto:contact@agentlens.one?subject=Enterprise%20Security%20Review">Contact Security & Sales</a>
+      </div>
+      <div class="kpi">
+        <div class="box"><div class="v status">Live</div><div class="l">Security Policy page</div></div>
+        <div class="box"><div class="v status">Live</div><div class="l">Subprocessor page</div></div>
+        <div class="box"><div class="v status">Live</div><div class="l">Health/Readiness endpoints</div></div>
+        <div class="box"><div class="v status">Live</div><div class="l">Compliance console flows</div></div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h3>Security Posture</h3>
+        <p>Auth, transport hardening, API-key governance, and vulnerability disclosure process are documented and externally accessible.</p>
+        <div class="mini"><a href="/security">Open Security Policy</a></div>
+      </article>
+      <article class="card">
+        <h3>Data Lifecycle Controls</h3>
+        <p>Export, retention, delete, and audit-log workflows are available through the compliance console for governance operations.</p>
+        <div class="mini"><a href="/compliance.html?api_key=al_demo_agentlens">Open Compliance Console</a></div>
+      </article>
+      <article class="card">
+        <h3>Vendor Transparency</h3>
+        <p>Subprocessor list and data-flow context are published to support legal/security questionnaires and procurement checks.</p>
+        <div class="mini"><a href="/subprocessors">Open Subprocessor List</a></div>
+      </article>
+      <article class="card">
+        <h3>Operational Reliability</h3>
+        <p>Health endpoints and uptime workflow are implemented, with backup/restore protocol and restore-test evidence in place.</p>
+        <div class="mini">Endpoints: <code>/healthz</code>, <code>/readyz</code>, <code>/health</code></div>
+      </article>
+    </section>
+
+    <section class="stack">
+      <article class="card">
+        <h2>Procurement Package (v1)</h2>
+        <p>Initial package includes AVV/DPA template, SLA draft, security FAQ, runbook, subprocessors, and governance controls. Available for security/legal review kickoff.</p>
+        <ul>
+          <li>Data processing and TOM baseline</li>
+          <li>SLA response and availability targets</li>
+          <li>Incident communication and recovery process</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Governance Maturity (Current)</h2>
+        <ul>
+          <li>RBAC minimum implemented: <code>admin</code>, <code>analyst</code>, <code>read_only</code></li>
+          <li>Key rotation and admin action auditing expanded</li>
+          <li>Retention warning logic in UI to prevent unsafe policy choices</li>
+          <li>OIDC-first SSO decision path documented</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Enterprise Sales Motion</h2>
+        <p>Standardized POC designs and ROI model support pilot-to-contract conversion with clear compliance-first and cost+quality tracks.</p>
+        <ul>
+          <li>POC A: EU Compliance Focus</li>
+          <li>POC B: Cost + Quality Focus</li>
+          <li>Objection handling for LangSmith / Langfuse / Datadog</li>
+        </ul>
+      </article>
+    </section>
+
+    <footer>
+      AgentLens Trust Center · For formal reviews contact <a href="mailto:contact@agentlens.one">contact@agentlens.one</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/dashboard/landing.html
+++ b/dashboard/landing.html
@@ -96,6 +96,12 @@
     .demo-box p { color: var(--muted); font-size: 0.875rem; margin-bottom: 1.25rem; }
     .demo-links { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
 
+    .trust-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:1rem; margin-top:1.5rem; }
+    .trust-card { background: var(--surface); border:1px solid var(--border); border-radius:10px; padding:1.1rem; }
+    .trust-card h3 { font-size:0.95rem; margin-bottom:0.35rem; }
+    .trust-card p { font-size:0.8rem; color:var(--muted); }
+    .trust-links { margin-top:1.1rem; display:flex; gap:0.8rem; flex-wrap:wrap; font-size:0.85rem; }
+
     /* Footer */
     footer { border-top: 1px solid var(--border); padding: 2rem; text-align: center; color: var(--muted); font-size: 0.8rem; margin-top: 4rem; }
 
@@ -128,6 +134,7 @@
   </div>
   <div class="nav-links">
     <a href="#features">Features</a>
+    <a href="/enterprise">Enterprise</a>
     <a href="#pricing">Pricing</a>
     <a href="https://github.com/Soufianeazz/agentlens" target="_blank">GitHub</a>
     <a href="/dashboard?api_key=al_demo_agentlens" class="btn btn-outline">Live Demo</a>
@@ -152,6 +159,35 @@
     <div><span class="code-comment"># Full setup. Nothing else needed.</span></div>
     <div>agentlens.<span class="code-fn">init</span>(<span class="code-str">"https://agentlens.your-company.com"</span>)</div>
     <div>agentlens.<span class="code-fn">patch_openai</span>()  <span class="code-comment"># every call tracked automatically</span></div>
+  </div>
+</section>
+
+<!-- Enterprise Trust -->
+<section class="section" id="enterprise">
+  <div class="section-label">Enterprise Trust</div>
+  <h2>Built to pass security review without slowing sales cycles</h2>
+  <p>AgentLens now exposes compliance and trust material directly on the website, with clear controls, governance posture, and operational readiness.</p>
+
+  <div class="trust-grid">
+    <div class="trust-card">
+      <h3>Security & Governance</h3>
+      <p>Published security policy, vulnerability intake process, RBAC minimum, and API key rotation governance.</p>
+    </div>
+    <div class="trust-card">
+      <h3>Compliance Lifecycle</h3>
+      <p>Export, retention, delete, and audit-log flows are visible and demoable for procurement and security teams.</p>
+    </div>
+    <div class="trust-card">
+      <h3>Reliability Proof</h3>
+      <p>Health/readiness endpoints, uptime alert workflow, backup strategy, and restore-drill protocol are in place.</p>
+    </div>
+  </div>
+
+  <div class="trust-links">
+    <a href="/enterprise">Enterprise Trust Center</a>
+    <a href="/security">Security Policy</a>
+    <a href="/subprocessors">Subprocessors</a>
+    <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
   </div>
 </section>
 
@@ -434,6 +470,9 @@
 <footer>
   <p>AgentLens · MIT License · <a href="https://github.com/Soufianeazz/agentlens">GitHub</a> · <a href="https://pypi.org/project/agentlens-monitor">PyPI</a> · <a href="mailto:contact@agentlens.one">contact@agentlens.one</a></p>
   <p style="margin-top:0.5rem;">
+    <a href="/enterprise">Enterprise Trust Center</a> ·
+    <a href="/security">Security</a> ·
+    <a href="/subprocessors">Subprocessors</a> ·
     <a href="/impressum.html">Impressum</a> ·
     <a href="/datenschutz.html">Datenschutz</a> ·
     <a href="/nutzungsbedingungen.html">Nutzungsbedingungen</a>

--- a/dashboard/security.html
+++ b/dashboard/security.html
@@ -3,73 +3,201 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Security Policy - AgentLens</title>
+  <title>Security Trust - AgentLens</title>
+  <meta name="description" content="AgentLens security trust page for enterprise buyers: architecture controls, access model, incident handling, and reporting path." />
   <style>
-    body { margin: 0; padding: 2rem; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0b1020; color: #e6ecff; }
-    .wrap { max-width: 920px; margin: 0 auto; }
-    a { color: #7dd3fc; }
-    h1 { margin: 0 0 0.5rem 0; font-size: 2rem; }
-    h2 { margin-top: 2rem; font-size: 1.15rem; color: #bfdbfe; }
-    p, li { color: #cbd5e1; line-height: 1.6; }
-    .meta { color: #93c5fd; font-size: 0.95rem; margin-bottom: 1.5rem; }
-    .card { background: #111a33; border: 1px solid #243053; border-radius: 10px; padding: 1rem 1.2rem; margin-top: 1rem; }
-    code { background: #1e2a4a; border: 1px solid #2e3e67; padding: 0.12rem 0.35rem; border-radius: 6px; }
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #081021;
+      --bg2: #0f1b36;
+      --surface: #101b34;
+      --surface2: #162647;
+      --border: #2a3f68;
+      --text: #eef3ff;
+      --muted: #a9badb;
+      --accent: #7ea2ff;
+      --ok: #66da9b;
+    }
+    body {
+      margin: 0;
+      font-family: "Segoe UI Variable", "Aptos", "Trebuchet MS", system-ui, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(1200px 420px at 10% -5%, #1a2d57 0%, rgba(26, 45, 87, 0) 55%),
+        linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+    }
+    a { color: #b9ccff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 1.4rem 1.2rem 2.6rem; }
+    .topbar { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
+    .brand { font-weight: 800; letter-spacing: 0.2px; }
+    .brand span { color: var(--accent); }
+    .links { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+    .links a {
+      border: 1px solid var(--border);
+      background: rgba(15, 27, 54, 0.75);
+      border-radius: 8px;
+      padding: 0.45rem 0.72rem;
+      font-size: 0.8rem;
+    }
+    .hero {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: linear-gradient(180deg, rgba(16, 27, 52, 0.96), rgba(11, 20, 39, 0.96));
+      padding: 1.2rem;
+    }
+    .tag {
+      display: inline-block;
+      border: 1px solid #3b5485;
+      color: #c5d5f3;
+      border-radius: 999px;
+      padding: 0.18rem 0.62rem;
+      font-size: 0.72rem;
+    }
+    h1 { margin: 0.7rem 0 0.5rem; font-size: clamp(1.5rem, 3.4vw, 2.25rem); line-height: 1.15; }
+    .hero p { margin: 0; color: var(--muted); max-width: 760px; }
+    .meta { margin-top: 0.8rem; font-size: 0.78rem; color: #c0d0ee; }
+    .kpi {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.65rem;
+    }
+    .kpi .box {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.7rem;
+    }
+    .kpi .v { font-size: 1.12rem; font-weight: 800; color: var(--ok); }
+    .kpi .l { margin-top: 0.15rem; color: var(--muted); font-size: 0.75rem; }
+    .grid {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 0.9rem;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      padding: 1rem;
+    }
+    .card h2 { margin: 0.05rem 0 0.35rem; font-size: 1rem; }
+    .card p { margin: 0; color: var(--muted); font-size: 0.84rem; line-height: 1.6; }
+    .card ul { margin: 0.55rem 0 0 1rem; padding: 0; }
+    .card li { color: var(--muted); font-size: 0.82rem; line-height: 1.56; }
+    .status { color: var(--ok); font-weight: 700; }
+    .inline-links {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      background: rgba(16, 27, 52, 0.82);
+      border-radius: 10px;
+      padding: 0.85rem;
+      display: flex;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+      font-size: 0.82rem;
+    }
+    footer { margin-top: 1.6rem; text-align: center; font-size: 0.78rem; color: var(--muted); }
+    @media (max-width: 560px) {
+      .wrap { padding: 1rem 0.85rem 2rem; }
+    }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <p><a href="/">Back to Dashboard</a></p>
-    <h1>Security Policy</h1>
-    <p class="meta">Last updated: 2026-05-02</p>
-
-    <div class="card">
-      <h2>Authentication and Access</h2>
-      <ul>
-        <li>API endpoints are protected by API keys (<code>X-API-Key</code> or <code>?api_key=</code>).</li>
-        <li>Invalid or inactive keys are rejected with authorization errors.</li>
-        <li>RBAC MVP roles are defined as <code>Admin</code>, <code>Analyst</code>, and <code>Read-only</code>.</li>
-      </ul>
+    <div class="topbar">
+      <div class="brand">Agent<span>Lens</span> Security</div>
+      <div class="links">
+        <a href="/">Home</a>
+        <a href="/enterprise">Enterprise</a>
+        <a href="/subprocessors">Subprocessors</a>
+        <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      </div>
     </div>
 
-    <div class="card">
-      <h2>Encryption and Transport Security</h2>
-      <ul>
-        <li>TLS is required for hosted traffic.</li>
-        <li>Security headers include HSTS, CSP, X-Frame-Options, and X-Content-Type-Options.</li>
-        <li>Database backups must be encrypted at rest in backup storage.</li>
-      </ul>
+    <section class="hero">
+      <span class="tag">Public Security Trust Page</span>
+      <h1>Security controls built for enterprise procurement and production AI</h1>
+      <p>AgentLens is designed so legal, security, and engineering teams can evaluate controls without back-and-forth. This page summarizes the operating baseline for hosted deployments and enterprise rollouts.</p>
+      <div class="meta">Last updated: 2026-05-02</div>
+      <div class="kpi">
+        <div class="box"><div class="v status">Active</div><div class="l">Security headers enforced</div></div>
+        <div class="box"><div class="v status">Active</div><div class="l">API key auth + RBAC minimum</div></div>
+        <div class="box"><div class="v status">Active</div><div class="l">Audit events for governance actions</div></div>
+        <div class="box"><div class="v status">Active</div><div class="l">Health/readiness endpoints published</div></div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2>Identity and Access</h2>
+        <p>API endpoints require valid credentials, with role-based access model and scoped admin actions.</p>
+        <ul>
+          <li>API keys accepted via <code>X-API-Key</code> or <code>?api_key=</code>.</li>
+          <li>RBAC baseline roles: <code>admin</code>, <code>analyst</code>, <code>read_only</code>.</li>
+          <li>Key rotation process is defined with audit evidence.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Network and Application Hardening</h2>
+        <p>Security posture includes transport controls and default response protections on production traffic.</p>
+        <ul>
+          <li>TLS is required for hosted traffic paths.</li>
+          <li>Headers include CSP, HSTS, frame and content-type protections.</li>
+          <li>Request-size limits reduce abuse risk on ingest endpoints.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Data Governance and Auditability</h2>
+        <p>Operational and compliance actions are visible and traceable for legal and regulatory checks.</p>
+        <ul>
+          <li>Export, delete, and retention actions are captured in audit events.</li>
+          <li>Compliance console supports evidence-oriented workflows.</li>
+          <li>Trace records support debugging and incident reconstruction.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Resilience and Recovery</h2>
+        <p>Reliability controls cover runtime checks, backup policy, and incident communication paths.</p>
+        <ul>
+          <li>Health endpoints: <code>/healthz</code>, <code>/readyz</code>, <code>/health</code>.</li>
+          <li>Backup and restore process is documented with drill expectations.</li>
+          <li>Uptime workflow supports proactive alerting.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Vulnerability Reporting</h2>
+        <p>Security reports are reviewed through a documented intake flow.</p>
+        <ul>
+          <li>Report channel: <a href="mailto:security@agentlens.one">security@agentlens.one</a></li>
+          <li>Severity-based response and communication process is defined.</li>
+          <li>Enterprise customers can request direct security review calls.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Scope Note</h2>
+        <p>This trust page represents the operational baseline and public controls summary. Contractual commitments are finalized in customer DPA/SLA documents.</p>
+      </article>
+    </section>
+
+    <div class="inline-links">
+      <a href="/enterprise">Enterprise Trust Center</a>
+      <a href="/subprocessors">Subprocessor List</a>
+      <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      <a href="mailto:contact@agentlens.one?subject=Security%20Review%20Request">Request Security Review</a>
     </div>
 
-    <div class="card">
-      <h2>Logging and Auditability</h2>
-      <ul>
-        <li>Compliance actions (export, delete, retention changes) are written to the audit log.</li>
-        <li>API key rotation audit event schema is documented for full traceability.</li>
-        <li>Operational traces are available for debugging and post-incident analysis.</li>
-      </ul>
-    </div>
-
-    <div class="card">
-      <h2>Backups and Recovery</h2>
-      <ul>
-        <li>Backup and restore process is documented with RPO/RTO targets.</li>
-        <li>Restore drill evidence is maintained in enterprise documentation.</li>
-      </ul>
-    </div>
-
-    <div class="card">
-      <h2>Vulnerability Reporting</h2>
-      <p>Security issues can be reported to <a href="mailto:security@agentlens.one">security@agentlens.one</a>.
-      Process and SLAs are documented in the vulnerability process document.</p>
-    </div>
-
-    <div class="card">
-      <h2>References</h2>
-      <ul>
-        <li><a href="/subprocessors">Subprocessor List</a></li>
-        <li><a href="/compliance.html">Compliance Controls</a></li>
-      </ul>
-    </div>
+    <footer>
+      AgentLens Security Trust - for review requests contact <a href="mailto:security@agentlens.one">security@agentlens.one</a>
+    </footer>
   </div>
 </body>
 </html>

--- a/dashboard/sitemap.xml
+++ b/dashboard/sitemap.xml
@@ -40,4 +40,19 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.agentlens.one/enterprise</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.agentlens.one/security</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.agentlens.one/subprocessors</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/dashboard/subprocessors.html
+++ b/dashboard/subprocessors.html
@@ -3,79 +3,257 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Subprocessors - AgentLens</title>
+  <title>Subprocessors and Data Flow - AgentLens</title>
+  <meta name="description" content="AgentLens enterprise subprocessor registry with purpose, data categories, geography, and operational status." />
   <style>
-    body { margin: 0; padding: 2rem; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0b1020; color: #e6ecff; }
-    .wrap { max-width: 1040px; margin: 0 auto; }
-    a { color: #7dd3fc; }
-    h1 { margin: 0 0 0.5rem 0; font-size: 2rem; }
-    .meta { color: #93c5fd; font-size: 0.95rem; margin-bottom: 1.5rem; }
-    table { width: 100%; border-collapse: collapse; background: #111a33; border: 1px solid #243053; border-radius: 10px; overflow: hidden; }
-    th, td { text-align: left; vertical-align: top; padding: 0.8rem; border-bottom: 1px solid #243053; color: #cbd5e1; }
-    th { color: #bfdbfe; background: #182446; }
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #071020;
+      --bg2: #0e1a32;
+      --surface: #101b34;
+      --surface2: #152543;
+      --border: #2b4169;
+      --text: #eef3ff;
+      --muted: #a9b9d8;
+      --accent: #7ea2ff;
+      --ok: #66da9b;
+      --warn: #f6bf65;
+    }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: "Segoe UI Variable", "Aptos", "Trebuchet MS", system-ui, sans-serif;
+      background:
+        radial-gradient(1100px 380px at 10% -8%, #1a2d57 0%, rgba(26, 45, 87, 0) 55%),
+        linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+    }
+    a { color: #c1d1ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1160px; margin: 0 auto; padding: 1.35rem 1.15rem 2.5rem; }
+    .topbar { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
+    .brand { font-weight: 800; }
+    .brand span { color: var(--accent); }
+    .links { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+    .links a {
+      border: 1px solid var(--border);
+      background: rgba(15, 27, 54, 0.75);
+      border-radius: 8px;
+      padding: 0.45rem 0.72rem;
+      font-size: 0.8rem;
+    }
+    .hero {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: linear-gradient(180deg, rgba(16, 27, 52, 0.96), rgba(11, 20, 39, 0.96));
+      padding: 1.15rem;
+    }
+    .tag {
+      display: inline-block;
+      border: 1px solid #3b5485;
+      color: #c5d5f3;
+      border-radius: 999px;
+      padding: 0.18rem 0.62rem;
+      font-size: 0.72rem;
+    }
+    h1 { margin: 0.7rem 0 0.5rem; font-size: clamp(1.45rem, 3.2vw, 2.2rem); line-height: 1.15; }
+    .hero p { margin: 0; color: var(--muted); max-width: 800px; }
+    .meta { margin-top: 0.8rem; color: #bfd0ef; font-size: 0.78rem; }
+
+    .stat-row {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.65rem;
+    }
+    .stat {
+      border: 1px solid var(--border);
+      background: var(--surface2);
+      border-radius: 10px;
+      padding: 0.68rem;
+    }
+    .stat .v { font-size: 1.1rem; font-weight: 800; }
+    .stat .l { margin-top: 0.15rem; color: var(--muted); font-size: 0.75rem; }
+
+    .panel {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 12px;
+      overflow: auto;
+    }
+    table { width: 100%; border-collapse: collapse; min-width: 840px; }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      padding: 0.8rem;
+      border-bottom: 1px solid #2a3d63;
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+    th {
+      background: #18284b;
+      color: #d8e4ff;
+      font-size: 0.77rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
     tr:last-child td { border-bottom: none; }
-    .note { margin-top: 1rem; color: #94a3b8; }
+    .chip {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 0.14rem 0.55rem;
+      font-size: 0.71rem;
+      border: 1px solid #35517f;
+      color: #c7d7f6;
+      background: #152542;
+      white-space: nowrap;
+    }
+    .chip.active { color: #b8ffd8; border-color: #2f6a50; background: #143225; }
+    .chip.optional { color: #ffe2b3; border-color: #7b5a27; background: #2f2412; }
+
+    .notes {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 0.85rem;
+    }
+    .note {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(16, 27, 52, 0.85);
+      padding: 0.9rem;
+    }
+    .note h2 { margin: 0.05rem 0 0.35rem; font-size: 0.96rem; }
+    .note p, .note li { color: var(--muted); font-size: 0.81rem; line-height: 1.58; }
+    .note ul { margin: 0.5rem 0 0 1rem; padding: 0; }
+    code { background: #1b2b4d; border: 1px solid #304976; border-radius: 6px; padding: 0.08rem 0.34rem; }
+    .inline-links {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      background: rgba(16, 27, 52, 0.82);
+      border-radius: 10px;
+      padding: 0.85rem;
+      display: flex;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+      font-size: 0.82rem;
+    }
+    footer { margin-top: 1.5rem; color: var(--muted); font-size: 0.78rem; text-align: center; }
+    @media (max-width: 560px) {
+      .wrap { padding: 1rem 0.85rem 2rem; }
+    }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <p><a href="/">Back to Dashboard</a></p>
-    <h1>Subprocessor List</h1>
-    <p class="meta">Last updated: 2026-05-02</p>
+    <div class="topbar">
+      <div class="brand">Agent<span>Lens</span> Subprocessors</div>
+      <div class="links">
+        <a href="/">Home</a>
+        <a href="/enterprise">Enterprise</a>
+        <a href="/security">Security</a>
+        <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      </div>
+    </div>
 
-    <table>
-      <thead>
-        <tr>
-          <th>Subprocessor</th>
-          <th>Purpose</th>
-          <th>Data Categories</th>
-          <th>Region</th>
-          <th>Status</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Railway</td>
-          <td>Application hosting and persistent runtime storage</td>
-          <td>LLM telemetry payloads, metadata, audit data</td>
-          <td>Per configured project region</td>
-          <td>Active</td>
-        </tr>
-        <tr>
-          <td>Anthropic (optional)</td>
-          <td>LLM-based quality judge for evaluations</td>
-          <td>Truncated input/output/prompt segments for scoring</td>
-          <td>Per configured account region</td>
-          <td>Optional</td>
-        </tr>
-        <tr>
-          <td>Stripe (optional)</td>
-          <td>Checkout and subscription billing</td>
-          <td>Billing and checkout session metadata</td>
-          <td>Per configured account region</td>
-          <td>Optional</td>
-        </tr>
-        <tr>
-          <td>Resend (optional)</td>
-          <td>Demo request notification emails</td>
-          <td>Name, email, company, message payload</td>
-          <td>Per configured account region</td>
-          <td>Optional</td>
-        </tr>
-        <tr>
-          <td>Customer-configured Webhook (optional)</td>
-          <td>Outbound operational notifications</td>
-          <td>Alert and lead event payloads</td>
-          <td>Customer-controlled destination</td>
-          <td>Optional</td>
-        </tr>
-      </tbody>
-    </table>
+    <section class="hero">
+      <span class="tag">Vendor Transparency Registry</span>
+      <h1>Subprocessors and operational data flow visibility</h1>
+      <p>This registry helps legal, procurement, and security teams understand where service data may be processed and why. It is updated as integrations evolve.</p>
+      <div class="meta">Last updated: 2026-05-02</div>
 
-    <p class="note">
-      For detailed data flow and legal-basis notes, refer to
-      <code>enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md</code>.
-    </p>
+      <div class="stat-row">
+        <div class="stat"><div class="v">5</div><div class="l">listed subprocessors</div></div>
+        <div class="stat"><div class="v" style="color:var(--ok)">1 active core</div><div class="l">required to run hosted service</div></div>
+        <div class="stat"><div class="v" style="color:var(--warn)">4 optional</div><div class="l">enabled by customer feature usage</div></div>
+        <div class="stat"><div class="v">Dynamic</div><div class="l">region follows configured account/project</div></div>
+      </div>
+    </section>
+
+    <section class="panel" aria-label="Subprocessor table">
+      <table>
+        <thead>
+          <tr>
+            <th>Subprocessor</th>
+            <th>Purpose</th>
+            <th>Data Categories</th>
+            <th>Region</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Railway</strong></td>
+            <td>Application hosting and persistent runtime storage</td>
+            <td>LLM telemetry payloads, metadata, and audit data</td>
+            <td>Per configured project region</td>
+            <td><span class="chip active">Active</span></td>
+          </tr>
+          <tr>
+            <td><strong>Anthropic</strong> (optional)</td>
+            <td>LLM quality judge for evaluation and scoring workloads</td>
+            <td>Truncated prompt/input/output excerpts used for scoring</td>
+            <td>Per configured account region</td>
+            <td><span class="chip optional">Optional</span></td>
+          </tr>
+          <tr>
+            <td><strong>Stripe</strong> (optional)</td>
+            <td>Checkout and subscription billing operations</td>
+            <td>Billing metadata and checkout session attributes</td>
+            <td>Per configured account region</td>
+            <td><span class="chip optional">Optional</span></td>
+          </tr>
+          <tr>
+            <td><strong>Resend</strong> (optional)</td>
+            <td>Demo request and sales notification emails</td>
+            <td>Name, email, company, and message form payload</td>
+            <td>Per configured account region</td>
+            <td><span class="chip optional">Optional</span></td>
+          </tr>
+          <tr>
+            <td><strong>Customer-configured Webhook</strong> (optional)</td>
+            <td>Outbound operational and alert notifications</td>
+            <td>Alert and lead event payloads</td>
+            <td>Customer-controlled destination</td>
+            <td><span class="chip optional">Optional</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="notes">
+      <article class="note">
+        <h2>How to interpret this table</h2>
+        <ul>
+          <li><strong>Active</strong> means required for base hosted runtime.</li>
+          <li><strong>Optional</strong> means processing occurs only if the customer enables that integration.</li>
+          <li>Region is tied to configured deployment or account settings.</li>
+        </ul>
+      </article>
+
+      <article class="note">
+        <h2>Data flow documentation</h2>
+        <p>Detailed legal basis and flow notes are maintained in the enterprise documentation set:</p>
+        <p><code>enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md</code></p>
+      </article>
+
+      <article class="note">
+        <h2>Change notification</h2>
+        <p>Subprocessor changes are reflected in this page and communicated through customer channels in line with contract commitments.</p>
+      </article>
+    </section>
+
+    <div class="inline-links">
+      <a href="/enterprise">Enterprise Trust Center</a>
+      <a href="/security">Security Trust Page</a>
+      <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      <a href="mailto:contact@agentlens.one?subject=Subprocessor%20Question">Ask legal/security question</a>
+    </div>
+
+    <footer>
+      AgentLens Subprocessor Registry - for review requests contact <a href="mailto:contact@agentlens.one">contact@agentlens.one</a>
+    </footer>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds premium enterprise trust presentation pages and routes to strengthen buyer confidence and procurement readiness.

## Included
- New `/enterprise` trust-center page
- Premium redesign of `/security`
- Premium redesign of `/subprocessors`
- New clean route handler for `/enterprise`
- Landing page trust section + enterprise nav links
- Sitemap entries for enterprise trust URLs

## Notes
- Focused on enterprise trust UX and discoverability
- Existing unrelated local file `SITE_AUDIT_2026-05-01.md` is intentionally not included