### PR TITLE
Complete day 6 security questionnaire pack and trust page

### DIFF
--- a/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
+++ b/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
@@ -73,7 +73,7 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ### Compliance & Legal
 - [ ] SLA finalisieren (Supportzeiten, Reaktionszeiten, Verfügbarkeit).
 - [ ] Security Annex + Data Processing Annex final paketieren.
-- [ ] Standard-Antwortpaket für Security Questionnaires vorbereiten.
+- [x] Standard-Antwortpaket für Security Questionnaires vorbereiten. (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md` + `dashboard/security-questionnaire.html`)
 
 ### Produkt & Betrieb
 - [ ] SSO/RBAC/Audit-Endzustand live und dokumentiert.
@@ -109,6 +109,10 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ### Tag 5
 - [x] Restore-Test durchführen und Ergebnis protokollieren. (2026-05-02, siehe `enterprise/RESTORE_TEST_PROTOCOL_2026-05-02.md`)
 - [x] Woche-1 Review: Gaps, Blocker, nächste 2 Wochen priorisieren. (2026-05-02, siehe `enterprise/WEEK1_REVIEW_2026-05-02.md`)
+
+### Tag 6
+- [x] Security Questionnaire Response Pack v1 erstellen (Standardantworten für Procurement/InfoSec). (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md`)
+- [x] Öffentliche Questionnaire-Seite unter Clean URL veröffentlichen. (2026-05-02, siehe `/security-questionnaire` + `dashboard/security-questionnaire.html`)
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -175,6 +175,11 @@ async def enterprise_page():
     return FileResponse("dashboard/enterprise.html")
 
 
+@app.get("/security-questionnaire", include_in_schema=False)
+async def security_questionnaire_page():
+    return FileResponse("dashboard/security-questionnaire.html")
+
+
 @app.get("/sitemap.xml", include_in_schema=False)
 async def sitemap():
     return FileResponse("dashboard/sitemap.xml", media_type="application/xml")

--- a/dashboard/enterprise.html
+++ b/dashboard/enterprise.html
@@ -51,6 +51,7 @@
         <a href="/">Home</a>
         <a href="/security">Security</a>
         <a href="/subprocessors">Subprocessors</a>
+        <a href="/security-questionnaire">Questionnaire</a>
         <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
       </div>
     </div>
@@ -76,6 +77,7 @@
         <h3>Security Posture</h3>
         <p>Auth, transport hardening, API-key governance, and vulnerability disclosure process are documented and externally accessible.</p>
         <div class="mini"><a href="/security">Open Security Policy</a></div>
+        <div class="mini"><a href="/security-questionnaire">Open Security Questionnaire Pack</a></div>
       </article>
       <article class="card">
         <h3>Data Lifecycle Controls</h3>

--- a/dashboard/landing.html
+++ b/dashboard/landing.html
@@ -187,6 +187,7 @@
     <a href="/enterprise">Enterprise Trust Center</a>
     <a href="/security">Security Policy</a>
     <a href="/subprocessors">Subprocessors</a>
+    <a href="/security-questionnaire">Security Questionnaire Pack</a>
     <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
   </div>
 </section>
@@ -473,6 +474,7 @@
     <a href="/enterprise">Enterprise Trust Center</a> ·
     <a href="/security">Security</a> ·
     <a href="/subprocessors">Subprocessors</a> ·
+    <a href="/security-questionnaire">Security Questionnaire</a> ·
     <a href="/impressum.html">Impressum</a> ·
     <a href="/datenschutz.html">Datenschutz</a> ·
     <a href="/nutzungsbedingungen.html">Nutzungsbedingungen</a>

--- a/dashboard/security-questionnaire.html
+++ b/dashboard/security-questionnaire.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Security Questionnaire - AgentLens</title>
+  <meta name="description" content="AgentLens standard enterprise security questionnaire response pack for InfoSec and procurement teams." />
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #081123;
+      --bg2: #10203c;
+      --surface: #111f3d;
+      --surface2: #172a4f;
+      --border: #314a79;
+      --text: #edf3ff;
+      --muted: #acbddb;
+      --accent: #7ea6ff;
+      --ok: #67dca1;
+    }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: "Segoe UI Variable", "Aptos", "Trebuchet MS", system-ui, sans-serif;
+      background:
+        radial-gradient(1200px 440px at 10% -8%, #1a3262 0%, rgba(26, 50, 98, 0) 56%),
+        linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+    }
+    a { color: #c4d4ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1140px; margin: 0 auto; padding: 1.4rem 1.15rem 2.6rem; }
+    .top { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
+    .brand { font-weight: 800; letter-spacing: 0.2px; }
+    .brand span { color: var(--accent); }
+    .nav { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+    .nav a {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(15, 28, 55, 0.78);
+      padding: 0.45rem 0.72rem;
+      font-size: 0.8rem;
+    }
+    .hero {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 1.2rem;
+      background: linear-gradient(180deg, rgba(17, 31, 61, 0.97), rgba(12, 22, 42, 0.97));
+    }
+    .tag {
+      display: inline-block;
+      border: 1px solid #3d5b90;
+      color: #c8d7f5;
+      border-radius: 999px;
+      padding: 0.18rem 0.62rem;
+      font-size: 0.72rem;
+    }
+    h1 { margin: 0.72rem 0 0.5rem; font-size: clamp(1.55rem, 3.4vw, 2.28rem); line-height: 1.14; }
+    .lead { margin: 0; color: var(--muted); max-width: 820px; }
+    .meta { margin-top: 0.78rem; color: #bfd0ef; font-size: 0.78rem; }
+    .kpis {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.7rem;
+    }
+    .kpi {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface2);
+      padding: 0.72rem;
+    }
+    .kpi .v { font-weight: 800; font-size: 1.13rem; color: var(--ok); }
+    .kpi .l { margin-top: 0.15rem; color: var(--muted); font-size: 0.75rem; }
+    .grid {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 0.9rem;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      padding: 0.95rem;
+    }
+    .card h2 { margin: 0.05rem 0 0.4rem; font-size: 0.98rem; }
+    .card p { margin: 0; color: var(--muted); font-size: 0.83rem; line-height: 1.58; }
+    .card ul { margin: 0.55rem 0 0 1rem; padding: 0; }
+    .card li { color: var(--muted); font-size: 0.81rem; line-height: 1.56; }
+    .links {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(17, 31, 61, 0.84);
+      padding: 0.85rem;
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.82rem;
+    }
+    footer { margin-top: 1.5rem; text-align: center; color: var(--muted); font-size: 0.78rem; }
+    @media (max-width: 560px) {
+      .wrap { padding: 1rem 0.85rem 2rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">Agent<span>Lens</span> Questionnaire</div>
+      <div class="nav">
+        <a href="/">Home</a>
+        <a href="/enterprise">Enterprise</a>
+        <a href="/security">Security</a>
+        <a href="/subprocessors">Subprocessors</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <span class="tag">Enterprise Security Questionnaire</span>
+      <h1>Standard InfoSec response pack for enterprise procurement</h1>
+      <p class="lead">This page provides a concise answer baseline for common buyer security questionnaires. It helps legal, InfoSec, and procurement teams complete first-pass due diligence faster.</p>
+      <div class="meta">Version 1.0 - Last updated: 2026-05-02</div>
+
+      <div class="kpis">
+        <div class="kpi"><div class="v">12</div><div class="l">response sections</div></div>
+        <div class="kpi"><div class="v">Public</div><div class="l">security + subprocessor references</div></div>
+        <div class="kpi"><div class="v">Live</div><div class="l">governance and compliance routes</div></div>
+        <div class="kpi"><div class="v">Fast</div><div class="l">first-pass buyer review flow</div></div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2>Company and Service Scope</h2>
+        <ul>
+          <li>AgentLens is an LLM observability platform for quality, hallucination, cost, and agent tracing.</li>
+          <li>Delivery model supports managed hosting and self-hosted deployment paths.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Security Program</h2>
+        <ul>
+          <li>Security contact mailbox: <a href="mailto:security@agentlens.one">security@agentlens.one</a>.</li>
+          <li>Vulnerability disclosure and triage process is documented and published.</li>
+          <li>Incident handling process and communication templates are maintained.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Access Control and Authentication</h2>
+        <ul>
+          <li>RBAC baseline roles: <code>admin</code>, <code>analyst</code>, <code>read_only</code>.</li>
+          <li>API requests require valid API key credentials.</li>
+          <li>Admin and governance actions are covered by audit logging.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Encryption and Transport</h2>
+        <ul>
+          <li>TLS is required for hosted traffic paths.</li>
+          <li>Response hardening includes HSTS, CSP, frame/content protections.</li>
+          <li>Backup storage follows encryption-at-rest requirements.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Auditability and Logging</h2>
+        <ul>
+          <li>Compliance actions (export/delete/retention) are audit captured.</li>
+          <li>CSV/JSON audit exports support customer review workflows.</li>
+          <li>Trace records support investigation and post-incident analysis.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Data Governance and Privacy</h2>
+        <ul>
+          <li>PII handling, retention controls, and delete/export flows are documented.</li>
+          <li>Retention warnings are exposed in compliance UI controls.</li>
+          <li>Customer-specific commitments are finalized in contract annexes.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Subprocessors and Regions</h2>
+        <ul>
+          <li>Public subprocessor register includes purpose and region behavior.</li>
+          <li>Optional integrations are clearly marked as conditional by feature usage.</li>
+          <li>Detailed data-flow context is available in enterprise documentation.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Reliability and Continuity</h2>
+        <ul>
+          <li>Health endpoints: <code>/healthz</code>, <code>/readyz</code>, <code>/health</code>.</li>
+          <li>Backup/restore process and restore-drill protocol are documented.</li>
+          <li>Uptime workflow supports operational alerting.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Secure Development</h2>
+        <ul>
+          <li>Controls and policy artifacts are versioned in GitHub.</li>
+          <li>Changes move through pull request workflow and merge history.</li>
+          <li>Phase-3 checklist includes formal change-management hardening.</li>
+        </ul>
+      </article>
+    </section>
+
+    <div class="links">
+      <a href="/enterprise">Enterprise Trust Center</a>
+      <a href="/security">Security Trust Page</a>
+      <a href="/subprocessors">Subprocessor Registry</a>
+      <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
+      <a href="mailto:contact@agentlens.one?subject=Security%20Questionnaire%20Review">Request Full Questionnaire Session</a>
+    </div>
+
+    <footer>
+      AgentLens Security Questionnaire Pack - for formal review contact <a href="mailto:contact@agentlens.one">contact@agentlens.one</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/dashboard/sitemap.xml
+++ b/dashboard/sitemap.xml
@@ -55,4 +55,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.agentlens.one/security-questionnaire</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md
+++ b/enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md
@@ -1,0 +1,69 @@
+# Security Questionnaire Response Pack v1
+
+Stand: 2026-05-02
+Owner: Founder + Engineering
+Version: 1.0
+
+## Purpose
+This document provides standard security questionnaire answers for enterprise buyers evaluating AgentLens.
+
+## 1) Company and Service
+- Legal Name: AgentLens (operated by founding team; legal entity details shared in contracting package).
+- Product Scope: LLM observability platform with quality scoring, hallucination detection, cost tracking, and agent debugging.
+- Delivery Models: Managed hosted deployment and self-hosted model.
+
+## 2) Security Program
+- Security contact: security@agentlens.one
+- Vulnerability intake process: documented in `enterprise/VULNERABILITY_DISCLOSURE_PROCESS.md`.
+- Incident process: documented in `enterprise/INCIDENT_RUNBOOK_TEMPLATE.md`.
+- Security policy page: `/security`
+
+## 3) Access Control
+- Minimum role model: `admin`, `analyst`, `read_only`.
+- API access: API key required via `X-API-Key` header or `?api_key=` query parameter.
+- Governance controls: admin actions and key governance actions are audit-logged.
+
+## 4) Authentication and SSO
+- Current baseline: API-key authentication with RBAC controls.
+- SSO direction: OIDC-first strategy documented in `enterprise/SSO_DECISION_PLAN_OIDC_FIRST.md`.
+
+## 5) Encryption and Transport
+- Transport: TLS required for hosted traffic.
+- Security headers: HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy.
+- Backup encryption expectation: encrypted backup storage per backup/restore process.
+
+## 6) Logging and Auditability
+- Audit logging for compliance operations (export/delete/retention actions) and governance-critical admin operations.
+- Audit export support: CSV and JSON with filterable ranges.
+- Operational traces support post-incident analysis and debug workflows.
+
+## 7) Data Governance and Privacy
+- PII handling policy documented in `enterprise/PII_HANDLING_POLICY.md`.
+- Retention controls and warnings available in compliance UI.
+- Data operations supported: export, retention updates, delete workflows with audit entries.
+
+## 8) Subprocessors and Data Residency
+- Public subprocessor register: `/subprocessors`
+- Detailed data-flow notes: `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md`
+- Region behavior: depends on configured project/account region and deployment setup.
+
+## 9) Reliability and Business Continuity
+- Health endpoints: `/healthz`, `/readyz`, `/health`
+- Uptime alerting: `.github/workflows/uptime-health-alert.yml`
+- Backup/restore process: `enterprise/BACKUP_RESTORE_PROCESS.md`
+- Restore drill protocol: `enterprise/RESTORE_TEST_PROTOCOL_2026-05-02.md`
+
+## 10) Secure Development and Change Control
+- Core controls are versioned in GitHub with pull request review flow.
+- Change transparency is provided via repository history and documented runbooks/processes.
+- Planned hardening: change-management policy formalization in Phase 3 checklist.
+
+## 11) Contract and Legal Pack
+- Procurement package: `enterprise/PROCUREMENT_PACK_V1.md`
+- DPA/AVV template: `enterprise/AVV_DPA_TEMPLATE_V1_FINAL.md`
+- SLA draft: `enterprise/SLA_DRAFT_V1.md`
+
+## 12) Standard Response Notes for Buyers
+- This pack is a baseline response set and may be expanded per customer questionnaire format.
+- Customer-specific security commitments are finalized in signed contractual documents.
+- For formal reviews or custom questionnaire sessions: contact@agentlens.one


### PR DESCRIPTION
## Summary
Implements Day 6 of the enterprise checklist by preparing and publishing a standard security questionnaire response pack.

## Included
- Added enterprise artifact: `SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md`
- Added public trust page: `/security-questionnaire`
- Added clean route in API for questionnaire page
- Linked questionnaire page from landing and enterprise trust center
- Added questionnaire URL to sitemap
- Updated enterprise checklist: Day 6 entries marked complete and phase-3 questionnaire item checked

## Notes
- Unrelated local file `SITE_AUDIT_2026-05-01.md` is intentionally not included