### PR TITLE
Complete day 7 SLA finalization and public SLA page

### DIFF
--- a/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
+++ b/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
@@ -71,7 +71,7 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ## Phase 3 (Tag 61–90) – Enterprise Close Readiness
 
 ### Compliance & Legal
-- [ ] SLA finalisieren (Supportzeiten, Reaktionszeiten, Verfügbarkeit).
+- [x] SLA finalisieren (Supportzeiten, Reaktionszeiten, Verfügbarkeit). (2026-05-02, siehe `enterprise/SLA_V2_FINAL.md` + `dashboard/sla.html`)
 - [ ] Security Annex + Data Processing Annex final paketieren.
 - [x] Standard-Antwortpaket für Security Questionnaires vorbereiten. (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md` + `dashboard/security-questionnaire.html`)
 
@@ -113,6 +113,10 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ### Tag 6
 - [x] Security Questionnaire Response Pack v1 erstellen (Standardantworten für Procurement/InfoSec). (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md`)
 - [x] Öffentliche Questionnaire-Seite unter Clean URL veröffentlichen. (2026-05-02, siehe `/security-questionnaire` + `dashboard/security-questionnaire.html`)
+
+### Tag 7
+- [x] SLA v2 finalisieren und customer-shareable dokumentieren. (2026-05-02, siehe `enterprise/SLA_V2_FINAL.md`)
+- [x] Öffentliche SLA-Seite unter Clean URL veröffentlichen. (2026-05-02, siehe `/sla` + `dashboard/sla.html`)
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -180,6 +180,11 @@ async def security_questionnaire_page():
     return FileResponse("dashboard/security-questionnaire.html")
 
 
+@app.get("/sla", include_in_schema=False)
+async def sla_page():
+    return FileResponse("dashboard/sla.html")
+
+
 @app.get("/sitemap.xml", include_in_schema=False)
 async def sitemap():
     return FileResponse("dashboard/sitemap.xml", media_type="application/xml")

--- a/dashboard/enterprise.html
+++ b/dashboard/enterprise.html
@@ -52,6 +52,7 @@
         <a href="/security">Security</a>
         <a href="/subprocessors">Subprocessors</a>
         <a href="/security-questionnaire">Questionnaire</a>
+        <a href="/sla">SLA</a>
         <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
       </div>
     </div>
@@ -105,6 +106,7 @@
           <li>SLA response and availability targets</li>
           <li>Incident communication and recovery process</li>
         </ul>
+        <div class="mini"><a href="/sla">Open SLA Commitments</a></div>
       </article>
 
       <article class="card">

--- a/dashboard/landing.html
+++ b/dashboard/landing.html
@@ -188,6 +188,7 @@
     <a href="/security">Security Policy</a>
     <a href="/subprocessors">Subprocessors</a>
     <a href="/security-questionnaire">Security Questionnaire Pack</a>
+    <a href="/sla">SLA Commitments</a>
     <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
   </div>
 </section>
@@ -475,6 +476,7 @@
     <a href="/security">Security</a> ·
     <a href="/subprocessors">Subprocessors</a> ·
     <a href="/security-questionnaire">Security Questionnaire</a> ·
+    <a href="/sla">SLA</a> ·
     <a href="/impressum.html">Impressum</a> ·
     <a href="/datenschutz.html">Datenschutz</a> ·
     <a href="/nutzungsbedingungen.html">Nutzungsbedingungen</a>

--- a/dashboard/security-questionnaire.html
+++ b/dashboard/security-questionnaire.html
@@ -114,6 +114,7 @@
         <a href="/enterprise">Enterprise</a>
         <a href="/security">Security</a>
         <a href="/subprocessors">Subprocessors</a>
+        <a href="/sla">SLA</a>
       </div>
     </div>
 
@@ -217,6 +218,7 @@
       <a href="/enterprise">Enterprise Trust Center</a>
       <a href="/security">Security Trust Page</a>
       <a href="/subprocessors">Subprocessor Registry</a>
+      <a href="/sla">SLA Commitments</a>
       <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
       <a href="mailto:contact@agentlens.one?subject=Security%20Questionnaire%20Review">Request Full Questionnaire Session</a>
     </div>

--- a/dashboard/sitemap.xml
+++ b/dashboard/sitemap.xml
@@ -60,4 +60,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.agentlens.one/sla</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/dashboard/sla.html
+++ b/dashboard/sla.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SLA Commitments - AgentLens</title>
+  <meta name="description" content="AgentLens service level commitments for enterprise buyers: availability, response targets, support coverage, and service credits." />
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #071022;
+      --bg2: #0f1d38;
+      --surface: #112040;
+      --surface2: #182c54;
+      --border: #334f83;
+      --text: #edf3ff;
+      --muted: #aebfde;
+      --accent: #82aaff;
+      --ok: #69dfa3;
+    }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: "Segoe UI Variable", "Aptos", "Trebuchet MS", system-ui, sans-serif;
+      background:
+        radial-gradient(1200px 420px at 10% -8%, #1b3466 0%, rgba(27, 52, 102, 0) 56%),
+        linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+    }
+    a { color: #c7d7ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1140px; margin: 0 auto; padding: 1.4rem 1.15rem 2.6rem; }
+    .top { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
+    .brand { font-weight: 800; }
+    .brand span { color: var(--accent); }
+    .nav { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+    .nav a {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(16, 30, 59, 0.8);
+      padding: 0.45rem 0.72rem;
+      font-size: 0.8rem;
+    }
+    .hero {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 1.2rem;
+      background: linear-gradient(180deg, rgba(17, 32, 64, 0.97), rgba(12, 22, 44, 0.97));
+    }
+    .tag {
+      display: inline-block;
+      border: 1px solid #3f5f98;
+      color: #cad9f7;
+      border-radius: 999px;
+      padding: 0.18rem 0.62rem;
+      font-size: 0.72rem;
+    }
+    h1 { margin: 0.72rem 0 0.5rem; font-size: clamp(1.55rem, 3.4vw, 2.28rem); line-height: 1.14; }
+    .lead { margin: 0; color: var(--muted); max-width: 830px; }
+    .meta { margin-top: 0.78rem; color: #bfd0ef; font-size: 0.78rem; }
+    .kpis {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.7rem;
+    }
+    .kpi {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface2);
+      padding: 0.72rem;
+    }
+    .kpi .v { font-weight: 800; font-size: 1.13rem; color: var(--ok); }
+    .kpi .l { margin-top: 0.15rem; color: var(--muted); font-size: 0.75rem; }
+    .grid {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 0.9rem;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      padding: 0.95rem;
+    }
+    .card h2 { margin: 0.05rem 0 0.4rem; font-size: 0.98rem; }
+    .card p { margin: 0; color: var(--muted); font-size: 0.83rem; line-height: 1.58; }
+    .card ul { margin: 0.55rem 0 0 1rem; padding: 0; }
+    .card li { color: var(--muted); font-size: 0.81rem; line-height: 1.56; }
+    .links {
+      margin-top: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(17, 32, 64, 0.84);
+      padding: 0.85rem;
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.82rem;
+    }
+    footer { margin-top: 1.5rem; text-align: center; color: var(--muted); font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">Agent<span>Lens</span> SLA</div>
+      <div class="nav">
+        <a href="/">Home</a>
+        <a href="/enterprise">Enterprise</a>
+        <a href="/security">Security</a>
+        <a href="/security-questionnaire">Questionnaire</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <span class="tag">Service Level Commitments</span>
+      <h1>Enterprise SLA baseline for reliability and support</h1>
+      <p class="lead">This public SLA summary helps procurement and operations teams evaluate service reliability, response targets, escalation behavior, and service-credit structure before contracting.</p>
+      <div class="meta">SLA v2 baseline - Last updated: 2026-05-02</div>
+
+      <div class="kpis">
+        <div class="kpi"><div class="v">99.9%</div><div class="l">monthly availability target</div></div>
+        <div class="kpi"><div class="v"><=1h</div><div class="l">Sev 1 initial response</div></div>
+        <div class="kpi"><div class="v">24/7</div><div class="l">Sev 1 escalation path</div></div>
+        <div class="kpi"><div class="v">RTO <=60m</div><div class="l">recovery target</div></div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2>Availability Scope</h2>
+        <ul>
+          <li>Commitment applies to managed hosted service.</li>
+          <li>Measurement window is monthly (UTC).</li>
+          <li>Planned maintenance with 48h notice is excluded from downtime.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Severity and Response</h2>
+        <ul>
+          <li>Sev 1: <= 1 hour initial response.</li>
+          <li>Sev 2: <= 4 hours initial response.</li>
+          <li>Sev 3: <= 1 business day initial response.</li>
+          <li>Sev 4: <= 2 business days initial response.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Support Coverage</h2>
+        <ul>
+          <li>Standard support: Mon-Fri, 09:00-18:00 CET/CEST.</li>
+          <li>Sev 1 incidents use 24/7 emergency on-call escalation.</li>
+          <li>Sev 1 and Sev 2 incidents include recurring status updates.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Incident Communication</h2>
+        <ul>
+          <li>Sev 1 first notice within 60 minutes after confirmation.</li>
+          <li>Sev 2 first notice within 4 hours after confirmation.</li>
+          <li>RCA-style summary provided for Sev 1 and Sev 2 incidents.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Backup and Recovery</h2>
+        <ul>
+          <li>RPO target: <= 24 hours.</li>
+          <li>RTO target: <= 60 minutes.</li>
+          <li>Restore-test protocol and backup process are documented.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Service Credits</h2>
+        <ul>
+          <li>99.0%-99.89%: 10% monthly service credit.</li>
+          <li>95.0%-98.99%: 25% monthly service credit.</li>
+          <li>Below 95.0%: 50% monthly service credit.</li>
+          <li>Claims submitted within 30 calendar days.</li>
+        </ul>
+      </article>
+    </section>
+
+    <div class="links">
+      <a href="/enterprise">Enterprise Trust Center</a>
+      <a href="/security">Security Trust Page</a>
+      <a href="/subprocessors">Subprocessor Registry</a>
+      <a href="/security-questionnaire">Security Questionnaire Pack</a>
+      <a href="mailto:contact@agentlens.one?subject=SLA%20Review">Request SLA Review</a>
+    </div>
+
+    <footer>
+      AgentLens SLA v2 baseline - for commercial review contact <a href="mailto:contact@agentlens.one">contact@agentlens.one</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/enterprise/SLA_V2_FINAL.md
+++ b/enterprise/SLA_V2_FINAL.md
@@ -1,0 +1,68 @@
+# SLA v2 Final (Customer-Shareable)
+
+Stand: 2026-05-02
+Owner: Legal + Engineering
+Status: Customer-shareable v2 baseline
+
+## 1. Scope
+- This SLA applies to the managed AgentLens hosted service.
+- Self-hosted deployments are excluded unless explicitly covered in a separate contract addendum.
+
+## 2. Service Availability Commitment
+- Monthly availability target: 99.9% for production API and core dashboard endpoints.
+- Measurement window: calendar month (UTC).
+- Excluded from downtime calculation:
+  - Planned maintenance announced at least 48 hours in advance.
+  - Force majeure events.
+  - Customer-side incidents or misconfiguration.
+
+## 3. Severity Classification and Initial Response Times
+- Sev 1 (critical outage or suspected security impact): initial response <= 1 hour (24/7).
+- Sev 2 (major degradation affecting key workflows): initial response <= 4 hours.
+- Sev 3 (partial degradation or non-critical defect): initial response <= 1 business day.
+- Sev 4 (low impact question/request): initial response <= 2 business days.
+
+## 4. Support Coverage
+- Standard support hours: Monday-Friday, 09:00-18:00 CET/CEST (excluding public holidays in Germany).
+- Sev 1 emergency path: 24/7 on-call escalation.
+
+## 5. Incident Communication Commitments
+- Sev 1: first customer communication within 60 minutes after confirmation.
+- Sev 2: first customer communication within 4 hours after confirmation.
+- Update cadence during active incident:
+  - Sev 1: every 60 minutes
+  - Sev 2: every 4 hours
+- Post-incident summary (RCA-style) is provided for Sev 1 and Sev 2 incidents.
+
+## 6. Backup and Recovery Targets
+- RPO target: <= 24 hours.
+- RTO target: <= 60 minutes.
+- Process references:
+  - `enterprise/BACKUP_RESTORE_PROCESS.md`
+  - `enterprise/RESTORE_TEST_PROTOCOL_2026-05-02.md`
+
+## 7. Service Credits
+- 99.0% to 99.89% monthly availability: 10% monthly service credit.
+- 95.0% to 98.99% monthly availability: 25% monthly service credit.
+- Below 95.0% monthly availability: 50% monthly service credit.
+- Credit cap: monthly recurring fee for the affected service month.
+
+## 8. Credit Claim Process
+- Customer submits claim within 30 calendar days after the affected month.
+- Claim must include account identifier, month, and incident references.
+- Approved credits are applied to the next invoice cycle.
+
+## 9. Customer Responsibilities
+- Protect customer-side access credentials and secret material.
+- Report service incidents promptly through agreed support channels.
+- Operate integrations within documented usage and rate limits.
+
+## 10. Security and Compliance References
+- Security policy page: `/security`
+- Security questionnaire pack: `/security-questionnaire`
+- Subprocessor register: `/subprocessors`
+- DPA/AVV template: `enterprise/AVV_DPA_TEMPLATE_V1_FINAL.md`
+
+## 11. Contract Notes
+- This SLA v2 is the baseline for commercial contracting.
+- Customer-specific adjustments (for example higher availability or custom support windows) may be documented in enterprise order forms or addenda.


### PR DESCRIPTION
## Summary
Implements Day 7 by finalizing SLA commitments and publishing a customer-facing SLA page in the enterprise trust journey.

## Included
- Added final enterprise SLA document: `enterprise/SLA_V2_FINAL.md`
- Added public SLA page: `/sla`
- Added clean route handler for `/sla`
- Linked SLA from landing, enterprise trust center, and questionnaire page
- Added `/sla` to sitemap
- Updated checklist: Phase 3 SLA item marked complete and Day 7 added

## Notes
- Unrelated local file `SITE_AUDIT_2026-05-01.md` remains excluded