### PR TITLE
Complete day 9 security questionnaire v2 and public page

### DIFF
--- a/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
+++ b/ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md
@@ -73,7 +73,7 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ### Compliance & Legal
 - [x] SLA finalisieren (Supportzeiten, Reaktionszeiten, Verfügbarkeit). (2026-05-02, siehe `enterprise/SLA_V2_FINAL.md` + `dashboard/sla.html`)
 - [x] Security Annex + Data Processing Annex final paketieren. (2026-05-02, siehe `enterprise/SECURITY_ANNEX_V1_FINAL.md` + `enterprise/DATA_PROCESSING_ANNEX_V1_FINAL.md` + `dashboard/legal-pack.html`)
-- [x] Standard-Antwortpaket für Security Questionnaires vorbereiten. (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md` + `dashboard/security-questionnaire.html`)
+- [x] Standard-Antwortpaket für Security Questionnaires vorbereiten. (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_RESPONSE_PACK_V1.md` + `enterprise/SECURITY_QUESTIONNAIRE_TOP30_V2.md` + `dashboard/security-questionnaire.html` + `dashboard/security-questionnaire-v2.html`)
 
 ### Produkt & Betrieb
 - [ ] SSO/RBAC/Audit-Endzustand live und dokumentiert.
@@ -121,6 +121,10 @@ Ziel: Abschlussfähigkeit für Enterprise-Deals in 90 Tagen.
 ### Tag 8
 - [x] Security Annex v1 Final und Data Processing Annex v1 Final paketieren. (2026-05-02, siehe `enterprise/SECURITY_ANNEX_V1_FINAL.md` + `enterprise/DATA_PROCESSING_ANNEX_V1_FINAL.md`)
 - [x] Öffentliche Legal-Pack-Seite unter Clean URL veröffentlichen. (2026-05-02, siehe `/legal-pack` + `dashboard/legal-pack.html`)
+
+### Tag 9
+- [x] Security Questionnaire Top-30 v2 erstellen (Q&A Standardantwortpaket). (2026-05-02, siehe `enterprise/SECURITY_QUESTIONNAIRE_TOP30_V2.md`)
+- [x] Öffentliche Questionnaire-v2-Seite unter Clean URL veröffentlichen. (2026-05-02, siehe `/security-questionnaire-v2` + `dashboard/security-questionnaire-v2.html`)
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -190,6 +190,11 @@ async def legal_pack_page():
     return FileResponse("dashboard/legal-pack.html")
 
 
+@app.get("/security-questionnaire-v2", include_in_schema=False)
+async def security_questionnaire_v2_page():
+    return FileResponse("dashboard/security-questionnaire-v2.html")
+
+
 @app.get("/sitemap.xml", include_in_schema=False)
 async def sitemap():
     return FileResponse("dashboard/sitemap.xml", media_type="application/xml")

--- a/dashboard/enterprise.html
+++ b/dashboard/enterprise.html
@@ -52,6 +52,7 @@
         <a href="/security">Security</a>
         <a href="/subprocessors">Subprocessors</a>
         <a href="/security-questionnaire">Questionnaire</a>
+        <a href="/security-questionnaire-v2">Questionnaire v2</a>
         <a href="/sla">SLA</a>
         <a href="/legal-pack">Legal Pack</a>
         <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
@@ -80,6 +81,7 @@
         <p>Auth, transport hardening, API-key governance, and vulnerability disclosure process are documented and externally accessible.</p>
         <div class="mini"><a href="/security">Open Security Policy</a></div>
         <div class="mini"><a href="/security-questionnaire">Open Security Questionnaire Pack</a></div>
+        <div class="mini"><a href="/security-questionnaire-v2">Open Top-30 Questionnaire Responses</a></div>
       </article>
       <article class="card">
         <h3>Data Lifecycle Controls</h3>

--- a/dashboard/landing.html
+++ b/dashboard/landing.html
@@ -188,6 +188,7 @@
     <a href="/security">Security Policy</a>
     <a href="/subprocessors">Subprocessors</a>
     <a href="/security-questionnaire">Security Questionnaire Pack</a>
+    <a href="/security-questionnaire-v2">Security Questionnaire Top-30</a>
     <a href="/sla">SLA Commitments</a>
     <a href="/legal-pack">Legal Pack</a>
     <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>
@@ -477,6 +478,7 @@
     <a href="/security">Security</a> ·
     <a href="/subprocessors">Subprocessors</a> ·
     <a href="/security-questionnaire">Security Questionnaire</a> ·
+    <a href="/security-questionnaire-v2">Security Q&A v2</a> ·
     <a href="/sla">SLA</a> ·
     <a href="/legal-pack">Legal Pack</a> ·
     <a href="/impressum.html">Impressum</a> ·

--- a/dashboard/legal-pack.html
+++ b/dashboard/legal-pack.html
@@ -111,6 +111,7 @@
         <a href="/enterprise">Enterprise</a>
         <a href="/security">Security</a>
         <a href="/sla">SLA</a>
+        <a href="/security-questionnaire-v2">Questionnaire v2</a>
       </div>
     </div>
 
@@ -170,6 +171,7 @@
       <a href="/enterprise">Enterprise Trust Center</a>
       <a href="/security">Security Trust Page</a>
       <a href="/security-questionnaire">Security Questionnaire</a>
+      <a href="/security-questionnaire-v2">Security Questionnaire Top-30 v2</a>
       <a href="/subprocessors">Subprocessors</a>
       <a href="mailto:contact@agentlens.one?subject=Legal%20Pack%20Review">Request Legal Pack Review</a>
     </div>

--- a/dashboard/security-questionnaire-v2.html
+++ b/dashboard/security-questionnaire-v2.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Security Questionnaire v2 - AgentLens</title>
+  <meta name="description" content="AgentLens Top-30 enterprise security questionnaire responses for procurement and InfoSec review." />
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #081124;
+      --bg2: #102140;
+      --surface: #112244;
+      --surface2: #18305c;
+      --border: #37568f;
+      --text: #edf4ff;
+      --muted: #b0c2e1;
+      --accent: #86afff;
+      --ok: #6ae1a6;
+    }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: "Segoe UI Variable", "Aptos", "Trebuchet MS", system-ui, sans-serif;
+      background:
+        radial-gradient(1200px 430px at 10% -8%, #1d376c 0%, rgba(29, 55, 108, 0) 56%),
+        linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+    }
+    a { color: #c9d9ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1160px; margin: 0 auto; padding: 1.4rem 1.15rem 2.6rem; }
+    .top { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
+    .brand { font-weight: 800; }
+    .brand span { color: var(--accent); }
+    .nav { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+    .nav a { border: 1px solid var(--border); border-radius: 8px; background: rgba(16, 32, 63, 0.8); padding: 0.45rem 0.72rem; font-size: 0.8rem; }
+    .hero { margin-top: 1rem; border: 1px solid var(--border); border-radius: 14px; padding: 1.2rem; background: linear-gradient(180deg, rgba(17, 34, 68, 0.97), rgba(12, 23, 46, 0.97)); }
+    .tag { display: inline-block; border: 1px solid #42639e; color: #cedcf9; border-radius: 999px; padding: 0.18rem 0.62rem; font-size: 0.72rem; }
+    h1 { margin: 0.72rem 0 0.5rem; font-size: clamp(1.55rem, 3.4vw, 2.28rem); line-height: 1.14; }
+    .lead { margin: 0; color: var(--muted); max-width: 860px; }
+    .meta { margin-top: 0.78rem; color: #bfd1f1; font-size: 0.78rem; }
+    .kpis { margin-top: 1rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.7rem; }
+    .kpi { border: 1px solid var(--border); border-radius: 10px; background: var(--surface2); padding: 0.72rem; }
+    .kpi .v { font-weight: 800; font-size: 1.13rem; color: var(--ok); }
+    .kpi .l { margin-top: 0.15rem; color: var(--muted); font-size: 0.75rem; }
+    .stack { margin-top: 1rem; display: grid; gap: 0.9rem; }
+    .section { border: 1px solid var(--border); border-radius: 12px; background: var(--surface); padding: 0.95rem; }
+    .section h2 { margin: 0.05rem 0 0.5rem; font-size: 1rem; }
+    .qa { margin: 0.6rem 0 0; display: grid; gap: 0.6rem; }
+    .item { border: 1px solid #2d4675; border-radius: 10px; padding: 0.7rem; background: rgba(15, 30, 58, 0.7); }
+    .q { font-size: 0.82rem; font-weight: 700; }
+    .a { margin-top: 0.3rem; color: var(--muted); font-size: 0.81rem; line-height: 1.55; }
+    .links { margin-top: 1rem; border: 1px solid var(--border); border-radius: 10px; background: rgba(17, 34, 68, 0.84); padding: 0.85rem; display: flex; gap: 0.75rem; flex-wrap: wrap; font-size: 0.82rem; }
+    footer { margin-top: 1.5rem; text-align: center; color: var(--muted); font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">Agent<span>Lens</span> Questionnaire v2</div>
+      <div class="nav">
+        <a href="/">Home</a>
+        <a href="/enterprise">Enterprise</a>
+        <a href="/security">Security</a>
+        <a href="/legal-pack">Legal Pack</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <span class="tag">Top-30 Security Questionnaire Responses</span>
+      <h1>Enterprise-ready baseline answers for procurement and InfoSec teams</h1>
+      <p class="lead">This v2 page answers the most common 30 security questionnaire prompts in concise format to accelerate first-pass security and legal review cycles.</p>
+      <div class="meta">Version 2.0 - Last updated: 2026-05-02</div>
+      <div class="kpis">
+        <div class="kpi"><div class="v">30</div><div class="l">standardized Q&A responses</div></div>
+        <div class="kpi"><div class="v">6</div><div class="l">question categories</div></div>
+        <div class="kpi"><div class="v">Public</div><div class="l">cross-referenced trust artifacts</div></div>
+        <div class="kpi"><div class="v">Fast</div><div class="l">first-pass buyer review support</div></div>
+      </div>
+    </section>
+
+    <section class="stack">
+      <article class="section">
+        <h2>Governance and Program (Q1-Q5)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q1. Formal security policy?</div><div class="a">Yes. Public baseline is available at <a href="/security">/security</a>.</div></div>
+          <div class="item"><div class="q">Q2. Security contact channel?</div><div class="a">Yes: <a href="mailto:security@agentlens.one">security@agentlens.one</a>.</div></div>
+          <div class="item"><div class="q">Q3. Incident response process?</div><div class="a">Yes. Severity, escalation, and communication process is documented.</div></div>
+          <div class="item"><div class="q">Q4. Vulnerability disclosure process?</div><div class="a">Yes. Intake and triage are formally defined.</div></div>
+          <div class="item"><div class="q">Q5. Security control review cadence?</div><div class="a">Controls are maintained through a versioned enterprise readiness roadmap.</div></div>
+        </div>
+      </article>
+
+      <article class="section">
+        <h2>Identity and Access (Q6-Q10)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q6. Role-based access?</div><div class="a">Yes. Baseline roles: <code>admin</code>, <code>analyst</code>, <code>read_only</code>.</div></div>
+          <div class="item"><div class="q">Q7. API authentication?</div><div class="a">API access requires valid API key credentials.</div></div>
+          <div class="item"><div class="q">Q8. Privileged action tracking?</div><div class="a">Yes. Governance-critical actions are audit logged.</div></div>
+          <div class="item"><div class="q">Q9. SSO support path?</div><div class="a">OIDC-first SSO direction is documented for enterprise rollout.</div></div>
+          <div class="item"><div class="q">Q10. Least privilege baseline?</div><div class="a">Role boundaries are defined and used as enforcement baseline.</div></div>
+        </div>
+      </article>
+
+      <article class="section">
+        <h2>Platform Security and Encryption (Q11-Q15)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q11. Encryption in transit?</div><div class="a">Yes. TLS is required for hosted service traffic.</div></div>
+          <div class="item"><div class="q">Q12. Security headers?</div><div class="a">Yes. CSP, HSTS, frame/content protections and related headers are applied.</div></div>
+          <div class="item"><div class="q">Q13. Backup encryption?</div><div class="a">Backup storage follows encryption-at-rest expectations.</div></div>
+          <div class="item"><div class="q">Q14. Abuse controls?</div><div class="a">Request-size and defensive protections are applied on relevant endpoints.</div></div>
+          <div class="item"><div class="q">Q15. Health endpoints?</div><div class="a">Yes: <code>/healthz</code>, <code>/readyz</code>, <code>/health</code>.</div></div>
+        </div>
+      </article>
+
+      <article class="section">
+        <h2>Audit, Monitoring, and Reliability (Q16-Q20, Q26-Q28)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q16-Q18. Audit exports and traces?</div><div class="a">Audit logs are exportable (CSV/JSON) and trace records support investigations.</div></div>
+          <div class="item"><div class="q">Q19-Q20. Monitoring and incident updates?</div><div class="a">Uptime monitoring and SLA-based communication cadence are in place.</div></div>
+          <div class="item"><div class="q">Q26-Q27. Recovery and restore testing?</div><div class="a">Baseline targets: RPO <= 24h, RTO <= 60m; restore drill protocol exists.</div></div>
+          <div class="item"><div class="q">Q28. SLA availability?</div><div class="a">Public SLA summary is available at <a href="/sla">/sla</a>.</div></div>
+        </div>
+      </article>
+
+      <article class="section">
+        <h2>Data Processing and Privacy (Q21-Q25)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q21-Q23. PII, retention, deletion/export controls?</div><div class="a">Documented PII policy and compliance workflows support retention and governance operations.</div></div>
+          <div class="item"><div class="q">Q24-Q25. Subprocessor transparency and data flow?</div><div class="a">Public subprocessor register and detailed flow notes are maintained.</div></div>
+        </div>
+      </article>
+
+      <article class="section">
+        <h2>Procurement and Contracting (Q29-Q30)</h2>
+        <div class="qa">
+          <div class="item"><div class="q">Q29. Legal/security procurement package?</div><div class="a">Yes. Consolidated at <a href="/legal-pack">/legal-pack</a>.</div></div>
+          <div class="item"><div class="q">Q30. Tailored questionnaire support?</div><div class="a">Yes. Baseline answers are adapted to customer-specific formats during review sessions.</div></div>
+        </div>
+      </article>
+    </section>
+
+    <div class="links">
+      <a href="/security">Security</a>
+      <a href="/security-questionnaire">Questionnaire v1</a>
+      <a href="/legal-pack">Legal Pack</a>
+      <a href="/sla">SLA</a>
+      <a href="mailto:contact@agentlens.one?subject=Security%20Questionnaire%20V2%20Review">Request Questionnaire Review Session</a>
+    </div>
+
+    <footer>
+      AgentLens Security Questionnaire v2 - contact <a href="mailto:security@agentlens.one">security@agentlens.one</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/dashboard/security-questionnaire.html
+++ b/dashboard/security-questionnaire.html
@@ -114,6 +114,7 @@
         <a href="/enterprise">Enterprise</a>
         <a href="/security">Security</a>
         <a href="/subprocessors">Subprocessors</a>
+        <a href="/security-questionnaire-v2">Questionnaire v2</a>
         <a href="/sla">SLA</a>
         <a href="/legal-pack">Legal Pack</a>
       </div>
@@ -219,6 +220,7 @@
       <a href="/enterprise">Enterprise Trust Center</a>
       <a href="/security">Security Trust Page</a>
       <a href="/subprocessors">Subprocessor Registry</a>
+      <a href="/security-questionnaire-v2">Security Questionnaire Top-30 v2</a>
       <a href="/sla">SLA Commitments</a>
       <a href="/legal-pack">Legal Pack</a>
       <a href="/compliance.html?api_key=al_demo_agentlens">Compliance Console</a>

--- a/dashboard/sitemap.xml
+++ b/dashboard/sitemap.xml
@@ -70,4 +70,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.agentlens.one/security-questionnaire-v2</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/dashboard/sla.html
+++ b/dashboard/sla.html
@@ -111,6 +111,7 @@
         <a href="/enterprise">Enterprise</a>
         <a href="/security">Security</a>
         <a href="/security-questionnaire">Questionnaire</a>
+        <a href="/security-questionnaire-v2">Questionnaire v2</a>
         <a href="/legal-pack">Legal Pack</a>
       </div>
     </div>
@@ -192,6 +193,7 @@
       <a href="/security">Security Trust Page</a>
       <a href="/subprocessors">Subprocessor Registry</a>
       <a href="/security-questionnaire">Security Questionnaire Pack</a>
+      <a href="/security-questionnaire-v2">Security Questionnaire Top-30 v2</a>
       <a href="/legal-pack">Legal Pack</a>
       <a href="mailto:contact@agentlens.one?subject=SLA%20Review">Request SLA Review</a>
     </div>

--- a/enterprise/SECURITY_QUESTIONNAIRE_TOP30_V2.md
+++ b/enterprise/SECURITY_QUESTIONNAIRE_TOP30_V2.md
@@ -1,0 +1,117 @@
+# Security Questionnaire Top 30 v2
+
+Stand: 2026-05-02
+Owner: Founder + Engineering
+Version: 2.0
+Status: Customer-shareable baseline
+
+## Purpose
+This document provides concise standard responses to the 30 most common enterprise security questionnaire prompts.
+
+## Governance and Program
+
+### Q1. Do you maintain a formal security policy?
+A1. Yes. A public baseline security policy is available at `/security` and mapped to internal enterprise controls documentation.
+
+### Q2. Is there a dedicated security contact channel?
+A2. Yes. Security inquiries and vulnerability reports are handled via `security@agentlens.one`.
+
+### Q3. Do you run an incident response process?
+A3. Yes. Incident severity classification, escalation, and communication workflow are documented in `enterprise/INCIDENT_RUNBOOK_TEMPLATE.md`.
+
+### Q4. Do you provide a vulnerability disclosure process?
+A4. Yes. Intake and triage flow are documented in `enterprise/VULNERABILITY_DISCLOSURE_PROCESS.md`.
+
+### Q5. How often are security controls reviewed?
+A5. Controls are reviewed and updated through a versioned enterprise readiness process tracked in `ENTERPRISE_READINESS_CHECKLIST_2026-05-02.md`.
+
+## Identity and Access
+
+### Q6. Is access control role-based?
+A6. Yes. Baseline roles are `admin`, `analyst`, and `read_only`.
+
+### Q7. How is API access authenticated?
+A7. API access requires valid API key credentials through supported request authentication patterns.
+
+### Q8. Are privileged actions tracked?
+A8. Yes. Governance-critical admin and compliance operations are audit logged.
+
+### Q9. Do you support SSO?
+A9. SSO direction is OIDC-first with implementation planning documented in `enterprise/SSO_DECISION_PLAN_OIDC_FIRST.md`.
+
+### Q10. Is least-privilege enforced?
+A10. Role boundaries are defined in the RBAC model and used as the enforcement baseline.
+
+## Encryption and Platform Security
+
+### Q11. Is data encrypted in transit?
+A11. Yes. TLS is required for hosted service traffic.
+
+### Q12. Are security headers enforced?
+A12. Yes. Response headers include CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.
+
+### Q13. Is backup storage encrypted?
+A13. Backup storage is expected to use encryption-at-rest controls per backup/restore policy.
+
+### Q14. Are request abuse protections in place?
+A14. Request-size limits and other defensive controls are applied to relevant ingestion paths.
+
+### Q15. Do you expose health endpoints for monitoring?
+A15. Yes. `/healthz`, `/readyz`, and `/health` are available.
+
+## Logging, Monitoring, and Audit
+
+### Q16. Are customer governance actions auditable?
+A16. Yes. Export, delete, and retention-related governance operations are represented in audit events.
+
+### Q17. Can audit logs be exported?
+A17. Yes. Audit export supports CSV and JSON with filterable ranges.
+
+### Q18. Is operational tracing available?
+A18. Yes. Trace records support debugging and incident reconstruction.
+
+### Q19. Is uptime monitored?
+A19. Yes. Health monitoring and uptime alert workflows are implemented.
+
+### Q20. Are incident updates provided during major events?
+A20. Yes. Communication cadence for major incidents follows SLA-defined severity expectations.
+
+## Data Processing and Privacy
+
+### Q21. How is personal data handled?
+A21. PII handling baseline is documented in `enterprise/PII_HANDLING_POLICY.md`.
+
+### Q22. Can customers control retention?
+A22. Yes. Retention controls are available through compliance workflows.
+
+### Q23. Can customers request deletion/export?
+A23. Yes. Data governance flows support export and deletion workflows.
+
+### Q24. Are sub-processors disclosed?
+A24. Yes. Public register available at `/subprocessors`.
+
+### Q25. Is data flow documentation available?
+A25. Yes. Detailed flow notes are documented in `enterprise/SUBPROCESSOR_LIST_AND_DATA_FLOW_V1.md`.
+
+## Reliability and Business Continuity
+
+### Q26. What are recovery targets?
+A26. Current baseline targets are RPO <= 24h and RTO <= 60m.
+
+### Q27. Is restore capability tested?
+A27. Yes. Restore drill protocol and evidence are documented in `enterprise/RESTORE_TEST_PROTOCOL_2026-05-02.md`.
+
+### Q28. Is an SLA available?
+A28. Yes. Public SLA summary is available at `/sla` with baseline commitments documented in `enterprise/SLA_V2_FINAL.md`.
+
+## Contracting and Procurement
+
+### Q29. Do you provide a legal/security package for procurement?
+A29. Yes. Legal pack is published at `/legal-pack` and includes DPA/AVV, Security Annex, Data Processing Annex, and SLA references.
+
+### Q30. Can responses be tailored to customer questionnaire formats?
+A30. Yes. This Top-30 baseline can be adapted to customer-specific templates during security/legal review.
+
+## Contact
+- Security intake: security@agentlens.one
+- Commercial/legal review: contact@agentlens.one


### PR DESCRIPTION
## Summary
Implements Day 9 by preparing a Top-30 security questionnaire answer pack and publishing a dedicated v2 questionnaire page.

## Included
- Added `enterprise/SECURITY_QUESTIONNAIRE_TOP30_V2.md`
- Added public page `/security-questionnaire-v2`
- Added route for `/security-questionnaire-v2`
- Linked v2 questionnaire from landing, enterprise, legal pack, SLA, and questionnaire v1 page
- Added `/security-questionnaire-v2` to sitemap
- Updated checklist with Day 9 completion and v2 references

## Notes
- Unrelated local file `SITE_AUDIT_2026-05-01.md` remains excluded