### PR TITLE
Fix enterprise contact button to avoid local Outlook client

### DIFF
--- a/dashboard/enterprise.html
+++ b/dashboard/enterprise.html
@@ -112,7 +112,7 @@
       <p class="lead">This page is designed for CTOs, InfoSec, Legal, and Procurement stakeholders evaluating AgentLens for enterprise rollout. It consolidates controls, governance evidence, and procurement-ready materials in one place.</p>
       <div class="cta">
         <a class="btn primary" href="/book-demo?plan=enterprise&source=trust-center">Book Enterprise Demo</a>
-        <a class="btn" href="mailto:contact@agentlens.one?subject=Enterprise%20Security%20Review">Contact Security & Sales</a>
+        <a class="btn" href="https://mail.google.com/mail/?view=cm&fs=1&to=contact@agentlens.one" target="_blank" rel="noopener">Contact Security & Sales</a>
       </div>
       <div class="kpi">
         <div class="box"><div class="v status">Live</div><div class="l">Security Policy page</div></div>


### PR DESCRIPTION
## Summary
Updates the `Contact Security & Sales` button on the enterprise page so it opens a browser-based compose flow to `contact@agentlens.one` instead of relying on local `mailto:` client handling.

## Change
- Replaced `mailto:` link with browser compose link:
  - `https://mail.google.com/mail/?view=cm&fs=1&to=contact@agentlens.one`
- Keeps button label and placement unchanged.